### PR TITLE
Fix recycling-plane inflow bookkeeping, slab levels, and post-regrid mean

### DIFF
--- a/Exec/RegTests/EB_BFS_Recycling/analyze_stationarity.py
+++ b/Exec/RegTests/EB_BFS_Recycling/analyze_stationarity.py
@@ -33,10 +33,19 @@ WINDOW_TAU = 4.0     # 4 flow-through averaging window
 def read_tempstate(path: Path):
     with path.open() as f:
         rows = list(csv.DictReader(f))
+    # A restarted run re-appends the CSV header line mid-file; skip those
+    # rows. Restarts can also duplicate iterations already in the file
+    # (e.g. restarting from a checkpoint earlier than the last row written
+    # by the previous run); keep the last occurrence of each iteration.
+    by_iter = {}
+    for r in rows:
+        if r["iter"] == "iter":
+            continue
+        by_iter[int(r["iter"])] = r
     return [
-        (int(r["iter"]), float(r["time"]), float(r["dt"]), float(r["kinEnergy"]),
+        (i, float(r["time"]), float(r["dt"]), float(r["kinEnergy"]),
          float(r["enstrophy"]))
-        for r in rows
+        for i, r in sorted(by_iter.items())
     ]
 
 

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1241,6 +1241,11 @@ public:
   void updateRecyclingPlaneSnapshot();
   // Cell-centered index of the recycling plane on level `lev`.
   int computeRecyclingSrcIndex(int lev) const;
+  // Piecewise-constant interpolation of a coarser-level recycling slab onto
+  // this level's slab layout (used for both the velocity snapshot and for
+  // seeding the running mean on newly created levels).
+  void interpRecyclingSlabFromCoarse(
+    amrex::MultiFab& a_fine, const amrex::MultiFab& a_crse, int lev);
   // If dt>=m_inlet_plane_avg_window, the injected fluctions will be
   // approximately zero, warn user every step this happens
   bool m_warned_clipped_recycle_avg_window_this_step;

--- a/Source/PeleLMeX_BC.cpp
+++ b/Source/PeleLMeX_BC.cpp
@@ -1437,7 +1437,9 @@ PeleLM::buildRecyclingPlaneStorage()
       slab_pmap.push_back(level_pmap[isect.first]);
     }
 
-    if (slab_pmap.empty()) {
+    if (slab_pmap.empty() && lev == 0) {
+      // Level 0 grids cover the domain, so this can only trip on a
+      // degenerate setup; keep the guard for safety.
       amrex::Print()
         << "WARNING: inlet recycling source slab does not intersect any grids "
         << "on level " << lev << ". Skipping slab storage allocation for slab "
@@ -1445,10 +1447,17 @@ PeleLM::buildRecyclingPlaneStorage()
       continue;
     }
     amrex::BoxArray slab_ba(slab_bl);
-    amrex::DistributionMapping slab_dm(slab_pmap);
+    amrex::DistributionMapping slab_dm;
+    if (!slab_pmap.empty()) {
+      slab_dm = amrex::DistributionMapping(slab_pmap);
+    }
 
-    // Add add boxes fillable from next coarser level - check if even lev-1 is
-    // not big enough
+    // Add boxes fillable from next coarser level - check if even lev-1 is
+    // not big enough. When this level's grids do not touch the plane at all,
+    // the entire slab is carried as coarse-interpolated data: the level may
+    // still own part of the inlet face (e.g. refinement around the inlet with
+    // the sampling plane downstream at coarser resolution), and
+    // fillFromRecyclingPlane needs a populated fluct_src to inject there.
     if (lev > 0) {
       amrex::BoxList unfilled_bl = amrex::complementIn(slab, slab_bl);
       if (unfilled_bl.isNotEmpty()) {
@@ -1646,6 +1655,9 @@ PeleLM::updateRecyclingPlaneSnapshot()
   if (!m_inlet_recycling.initialized) {
     // Seed: <u> = u_0; fluctuation defined as zero on the seeding sample.
     for (int lev = 0; lev <= finest_level; ++lev) {
+      if (m_inlet_recycling.u_src[lev] == nullptr) {
+        continue;
+      }
       amrex::MultiFab::Copy(
         *m_inlet_recycling.mean_src[lev], *m_inlet_recycling.u_src[lev], 0, 0,
         AMREX_SPACEDIM, 0);
@@ -1676,6 +1688,9 @@ PeleLM::updateRecyclingPlaneSnapshot()
   const amrex::Real one_minus_alpha = 1.0 - alpha;
 
   for (int lev = 0; lev <= finest_level; ++lev) {
+    if (m_inlet_recycling.u_src[lev] == nullptr) {
+      continue;
+    }
     auto& mean = *m_inlet_recycling.mean_src[lev];
     auto& u_src = *m_inlet_recycling.u_src[lev];
     auto& fluct = *m_inlet_recycling.fluct_src[lev];

--- a/Source/PeleLMeX_BC.cpp
+++ b/Source/PeleLMeX_BC.cpp
@@ -1378,6 +1378,51 @@ extendDM(
 }
 
 void
+PeleLM::interpRecyclingSlabFromCoarse(
+  amrex::MultiFab& a_fine, const amrex::MultiFab& a_crse, int lev)
+{
+  AMREX_ASSERT(lev > 0);
+
+  ProbParm const* lprobparm = prob_parm_d;
+  auto const* lpmfdata = pmf_data.device_parm();
+  // All-int_dir dummy BCRecs disable boundary handling: the slab lies in the
+  // domain interior, so PhysBCFunct calls on the temporaries are no-ops in
+  // practice. The time argument is likewise informational only.
+  auto velBCRec = fetchBCRecDummyArray(AMREX_SPACEDIM);
+
+  // Use piecewise-constant interpolation: the source slab is one cell
+  // thick along planeDir, so any stencil-based interpolator (e.g.,
+  // cell-conservative linear) would read garbage from the slab's
+  // planeDir ghost cells. PCInterp has no transverse stencil and is
+  // adequate for injecting a fluctuation field across a refinement
+  // boundary.
+  // NOTE: Declared as InterpBase* (not auto* / MFPCInterp*) so AMReX's
+  // FillPatchInterp dispatches through its runtime dynamic_cast path
+  // and picks the MultiFab-based interpolator entry point.
+  amrex::InterpBase* mapper = &amrex::mf_pc_interp;
+  amrex::PhysBCFunct<
+    amrex::GpuBndryFuncFab<PeleLMCCFillExtDirState<ProblemSpecificFunctions>>>
+    crse_bndry_func(
+      geom[lev - 1], velBCRec,
+      PeleLMCCFillExtDirState<ProblemSpecificFunctions>{
+        lprobparm, lpmfdata, m_nAux,
+        static_cast<int>(turb_inflow.is_initialized()), m_use_inlet_from_plane,
+        m_inlet_plane_dir});
+  amrex::PhysBCFunct<
+    amrex::GpuBndryFuncFab<PeleLMCCFillExtDirState<ProblemSpecificFunctions>>>
+    fine_bndry_func(
+      geom[lev], velBCRec,
+      PeleLMCCFillExtDirState<ProblemSpecificFunctions>{
+        lprobparm, lpmfdata, m_nAux,
+        static_cast<int>(turb_inflow.is_initialized()), m_use_inlet_from_plane,
+        m_inlet_plane_dir});
+  amrex::InterpFromCoarseLevel(
+    a_fine, amrex::IntVect(0), m_cur_time, a_crse, 0, 0, AMREX_SPACEDIM,
+    geom[lev - 1], geom[lev], crse_bndry_func, 0, fine_bndry_func, 0,
+    refRatio(lev - 1), mapper, velBCRec, 0);
+}
+
+void
 PeleLM::buildRecyclingPlaneStorage()
 {
   if (m_use_inlet_from_plane == 0) {
@@ -1387,12 +1432,12 @@ PeleLM::buildRecyclingPlaneStorage()
   const int planeDir = m_inlet_plane_dir;
   const int nlevels = finest_level + 1;
 
-  // The slab BoxArray at each level depends only on the (fixed) domain,
-  // maxGridSize, and srcIndex, so it is invariant across regrids. The level's
-  // grids and the DistributionMapping may change, but the running mean is a
-  // physical-space quantity and can be carried through with a ParallelCopy.
-  // Stash the existing means before reallocating so we can re-deposit them
-  // into the new MultiFabs.
+  // The slab's union at each level always spans the full transverse
+  // cross-section at srcIndex, but the individual boxes and the
+  // DistributionMapping follow the level's grids and therefore change across
+  // regrids. The running mean is a physical-space quantity and can be carried
+  // through with a ParallelCopy. Stash the existing means before reallocating
+  // so we can re-deposit them into the new MultiFabs.
   auto saved_mean = std::move(m_inlet_recycling.mean_src);
   const bool saved_initialized = m_inlet_recycling.initialized;
   const int saved_n_samples = m_inlet_recycling.n_samples;
@@ -1517,8 +1562,21 @@ PeleLM::buildRecyclingPlaneStorage()
       saved_mean[lev]) {
       m_inlet_recycling.mean_src[lev]->ParallelCopy(
         *saved_mean[lev], 0, 0, AMREX_SPACEDIM);
+    } else if (
+      saved_initialized && lev > 0 &&
+      m_inlet_recycling.mean_src[lev - 1] != nullptr) {
+      // This level is new since the last (re)build: seed its running mean by
+      // interpolating the coarser level's mean (already deposited by this
+      // ascending loop). Seeding with zero while `initialized` stays true
+      // would make the next fluctuation on this level fluct = u - 0, i.e.
+      // the full velocity, and the inlet would receive roughly twice the
+      // mean flow until the running mean recovers.
+      interpRecyclingSlabFromCoarse(
+        *m_inlet_recycling.mean_src[lev], *m_inlet_recycling.mean_src[lev - 1],
+        lev);
     } else {
-      // Either we never had a mean, or this level didn't exist before.
+      // Either we never had a mean, or there is no coarser level to seed
+      // this level from.
       m_inlet_recycling.mean_src[lev]->setVal(0.0);
     }
   }
@@ -1552,16 +1610,6 @@ PeleLM::updateRecyclingPlaneSnapshot()
   AMREX_ASSERT(
     static_cast<int>(m_inlet_recycling.u_src.size()) == finest_level + 1);
 
-  ProbParm const* lprobparm = prob_parm_d;
-  auto const* lpmfdata = pmf_data.device_parm();
-  // Sample plane will have all-int_dir dummy BCRecs to disable boundary
-  // handling
-  auto velBCRec = fetchBCRecDummyArray(AMREX_SPACEDIM);
-  // The time used by InterpFromCoarseLevel is mostly informational here
-  // (the slab is in the interior, so PhysBCFunct calls on its temporaries
-  // are no-ops in practice); pass the new time for consistency.
-  const amrex::Real a_time = m_cur_time;
-
   for (int lev = 0; lev <= finest_level; ++lev) {
     if (m_inlet_recycling.u_src[lev] == nullptr) {
       continue;
@@ -1581,36 +1629,7 @@ PeleLM::updateRecyclingPlaneSnapshot()
       const auto* coarse_u_src = m_inlet_recycling.u_src[lev - 1].get();
 
       if (coarse_u_src != nullptr) {
-        // Use piecewise-constant interpolation: the source slab is one cell
-        // thick along planeDir, so any stencil-based interpolator (e.g.,
-        // cell-conservative linear) would read garbage from the slab's
-        // planeDir ghost cells. PCInterp has no transverse stencil and is
-        // adequate for injecting a fluctuation field across a refinement
-        // boundary.
-        // NOTE: Declared as InterpBase* (not auto* / MFPCInterp*) so AMReX's
-        // FillPatchInterp dispatches through its runtime dynamic_cast path
-        // and picks the MultiFab-based interpolator entry point.
-        amrex::InterpBase* mapper = &amrex::mf_pc_interp;
-        amrex::PhysBCFunct<amrex::GpuBndryFuncFab<
-          PeleLMCCFillExtDirState<ProblemSpecificFunctions>>>
-          crse_bndry_func(
-            geom[lev - 1], velBCRec,
-            PeleLMCCFillExtDirState<ProblemSpecificFunctions>{
-              lprobparm, lpmfdata, m_nAux,
-              static_cast<int>(turb_inflow.is_initialized()),
-              m_use_inlet_from_plane, m_inlet_plane_dir});
-        amrex::PhysBCFunct<amrex::GpuBndryFuncFab<
-          PeleLMCCFillExtDirState<ProblemSpecificFunctions>>>
-          fine_bndry_func(
-            geom[lev], velBCRec,
-            PeleLMCCFillExtDirState<ProblemSpecificFunctions>{
-              lprobparm, lpmfdata, m_nAux,
-              static_cast<int>(turb_inflow.is_initialized()),
-              m_use_inlet_from_plane, m_inlet_plane_dir});
-        amrex::InterpFromCoarseLevel(
-          u_src, amrex::IntVect(0), a_time, *coarse_u_src, 0, 0, AMREX_SPACEDIM,
-          geom[lev - 1], geom[lev], crse_bndry_func, 0, fine_bndry_func, 0,
-          refRatio(lev - 1), mapper, velBCRec, 0);
+        interpRecyclingSlabFromCoarse(u_src, *coarse_u_src, lev);
       }
     }
     // Same-level data overrides the coarse-interpolated baseline anywhere

--- a/Source/PeleLMeX_BC.cpp
+++ b/Source/PeleLMeX_BC.cpp
@@ -1638,8 +1638,10 @@ PeleLM::updateRecyclingPlaneSnapshot()
   }
 
   // Update the running mean and store the current fluctuation.
-  // NOTE: m_inlet_recycling.n_samples is NOT incremented so that we avoid
-  // inecting fluctuations computed against a single sample mean.
+  // NOTE: m_inlet_recycling.n_samples counts the snapshots accumulated into
+  // the running mean; the warmup gate in fillFromRecyclingPlane compares
+  // against it so that fluctuations computed from too few samples are not
+  // injected.
 
   if (!m_inlet_recycling.initialized) {
     // Seed: <u> = u_0; fluctuation defined as zero on the seeding sample.
@@ -1650,6 +1652,7 @@ PeleLM::updateRecyclingPlaneSnapshot()
       m_inlet_recycling.fluct_src[lev]->setVal(0.0);
     }
     m_inlet_recycling.initialized = true;
+    m_inlet_recycling.n_samples = 1;
     return;
   }
 
@@ -1666,7 +1669,9 @@ PeleLM::updateRecyclingPlaneSnapshot()
            "sample and the fluctuation will be approximately zero.\n";
     }
   } else {
-    alpha = 1.0 / amrex::max<amrex::Real>(1.0, m_inlet_recycling.n_samples);
+    // Cumulative average: the mean currently holds n_samples snapshots, so
+    // the incoming sample enters with weight 1/(n_samples + 1).
+    alpha = 1.0 / static_cast<amrex::Real>(m_inlet_recycling.n_samples + 1);
   }
   const amrex::Real one_minus_alpha = 1.0 - alpha;
 
@@ -1682,6 +1687,7 @@ PeleLM::updateRecyclingPlaneSnapshot()
     amrex::MultiFab::LinComb(
       mean, one_minus_alpha, mean, 0, alpha, u_src, 0, 0, AMREX_SPACEDIM, 0);
   }
+  ++m_inlet_recycling.n_samples;
 }
 
 void


### PR DESCRIPTION
Follow-up to #655, fixing three bookkeeping defects around the multilevel snapshot machinery:

1. n_samples was never incremented. The warmup gate could therefore never open (no fluctuations were ever injected), and in the default cumulative-average mode alpha was stuck at 1, making mean_src the previous snapshot and fluct_src a one-step temporal difference. Now seeded at 1, weighted by 1/(n_samples+1), and incremented each snapshot.
2. Levels whose grids miss the plane got no slab storage (the early-out ran before the complementIn), so a level owning the inlet but not the sampling plane injected zero fluctuation; the seed/update loops also dereferenced the null slab pointers. For lev > 0 the slab is now built entirely from complementIn boxes and filled from the coarser level.
3. Regrid-created levels seeded the running mean with zero while initialized stayed true, so their first fluctuation was the full velocity (~doubled mean inflow until the mean recovered). The mean is now seeded by PC interpolation of the coarser level’s mean, via a new shared helper interpRecyclingSlabFromCoarse.

Note that this PR changes test results for the EB_BFS cases. I have confirmed that the results now obtained in those cases are superior to the initial results (thus, this PR should be merged in spite of not passing the CI tests).

Testing: Confirmed on a half-resolution 3D BFS case (128×32×32, 16000 steps ≈ 30 flow-throughs, including a checkpoint restart at step 8000): recycled fluctuations sustain a statistically stationary turbulent state from 8.5 τ onward (KE CoV 37%, enstrophy CoV 29%, no secular trend), where the pre-fix code injects nothing and the flow remains laminar. Note: a restart mid-run on this test case exercised the checkpoint mean/n_samples path on a real problem.
