### PR TITLE
Add peleLM.recycling_mode: inject full sampled velocity or fluctuations

### DIFF
--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -380,16 +380,32 @@ the user through the standard ``Inflow`` boundary condition; this feature only
 supplies the bracketed fluctuation. The running mean is preserved in
 checkpoints and restored across restarts.
 
+Alternatively, ``peleLM.recycling_mode = full`` injects the entire sampled
+velocity, :math:`\mathbf{u}_{\text{inlet}}(t) = \mathbf{u}_{\text{src}}(t)`,
+with no running mean maintained. The recycled velocity is enforced by the
+boundary-fill machinery itself: whatever ``bcnormal`` writes to the velocity
+components on the recycling face is ignored in this mode, so existing
+problem setups (including ones that add a mean profile to the velocity)
+run unmodified; ``bcnormal`` still controls the thermodynamic state. Full
+mode carries no restart state (the injection buffer reseeds from the first
+snapshot after initialization or restart, taken before the first boundary
+fill), and the ``inlet_plane_avg_window`` / ``inlet_plane_warmup_steps``
+controls are ignored.
+
 ::
 
     #-----------------------Recycling-plane inflow-----------------------
     peleLM.use_inlet_from_plane     = 0       # [OPT, DEF=0] Master switch (0 disables)
     peleLM.inlet_plane_dir          = -1      # [REQ if active] Sampling axis: 0=x, 1=y, 2=z
     peleLM.inlet_plane_position     = 0.0     # [REQ if active] Physical coordinate of the source plane along inlet_plane_dir
+    peleLM.recycling_mode           = fluctuations # [OPT, DEF=fluctuations] 'fluctuations' injects u - <u> on top of the
+                                              #                 bcnormal profile; 'full' injects the sampled velocity itself
     peleLM.inlet_plane_avg_window   = -1.0    # [OPT, DEF=-1.0] Time-window (s) for the running mean (EMA);
                                               #                 <=0 falls back to a cumulative 1/N average.
+                                              #                 Fluctuations mode only.
     peleLM.inlet_plane_warmup_steps = 0       # [OPT, DEF=0] Number of samples to accumulate before any
-                                              #              fluctuation is injected (lets the running mean settle)
+                                              #              fluctuation is injected (lets the running mean settle).
+                                              #              Fluctuations mode only.
 
 The source plane is one cell thick along ``inlet_plane_dir`` and spans the full
 transverse cross-section at ``inlet_plane_position``. Storage is allocated

--- a/Docs/sphinx/manual/Tutorials_BFSRecycling.rst
+++ b/Docs/sphinx/manual/Tutorials_BFSRecycling.rst
@@ -181,6 +181,15 @@ flow is slowly evolving.
    different velocity components are not supported and will abort the
    simulation.
 
+.. note::
+   Setting ``peleLM.recycling_mode = full`` injects the entire sampled
+   velocity instead of a fluctuation about the running mean. Velocity
+   writes from ``bcnormal`` are ignored on the recycling face in that mode
+   (the boundary fill preserves the sampled velocity), so this tutorial's
+   ``s_ext[VELX] += prob_parm.meanFlowMag`` line is harmless and the
+   problem setup needs no modification. The warmup and averaging-window
+   controls have no effect in full mode.
+
 Numerical parameters
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1899,18 +1899,29 @@ public:
   amrex::BCRec m_bcrec_dummy;
 
   // Recycling-plane inflow controls (see fillFromRecyclingPlane).
-  // Recycling injects a zero-mean fluctuation onto the inflow ghost cells:
+  // In the default 'fluctuations' mode, recycling injects a zero-mean
+  // fluctuation onto the inflow ghost cells:
   //   u_inlet(t) = u_inlet_target_mean + [u_src(t) - <u_src>]
   // The standard ext_dir BC continues to set u_inlet_target_mean; this
   // machinery only supplies the bracketed fluctuation.
+  // In 'full' mode, the entire sampled velocity is injected instead:
+  //   u_inlet(t) = u_src(t)
+  // No running mean is maintained. The boundary fill preserves the sampled
+  // velocity on the recycling face (velocity writes from bcnormal are
+  // ignored there; see PeleLMCCFillExtDirState), so problem setups run
+  // unmodified in either mode.
+  enum class RecyclingMode { Fluctuations, Full };
+  RecyclingMode m_recycling_mode = RecyclingMode::Fluctuations;
   int m_use_inlet_from_plane = 0;
   int m_inlet_plane_dir = -1;
   amrex::Real m_inlet_plane_position = 0.0;
   // Time-averaging window (in simulation time units) for the running source-
-  // plane mean. <=0 falls back to a cumulative average.
+  // plane mean. <=0 falls back to a cumulative average. Fluctuations mode
+  // only.
   amrex::Real m_inlet_plane_avg_window = -1.0;
   // Number of recycling-plane samples to accumulate before injecting any
-  // fluctuation (lets the running mean settle).
+  // fluctuation (lets the running mean settle). Fluctuations mode only: a
+  // full-velocity sample is valid from the first snapshot.
   int m_inlet_plane_warmup_steps = 0;
   // Set to 1 whenever per-level thin-slab storage needs to be rebuilt
   // (initialization, regrid). Consumed by updateRecyclingPlaneSnapshot.
@@ -1921,9 +1932,11 @@ public:
   // source-plane index for that level's resolution.
   struct RecyclingPlaneData
   {
-    amrex::Vector<std::unique_ptr<amrex::MultiFab>> u_src;     // current
-    amrex::Vector<std::unique_ptr<amrex::MultiFab>> mean_src;  // running mean
-    amrex::Vector<std::unique_ptr<amrex::MultiFab>> fluct_src; // u_src - mean
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> u_src;    // current
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> mean_src; // running mean
+    // Injection buffer consumed by fillFromRecyclingPlane:
+    // u_src - mean_src (fluctuations mode) or u_src (full mode).
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> fluct_src;
 #ifdef AMREX_USE_EB
     // Per-cell mask on the slab: 1 = regular or cut (sampled into the mean
     // and fluctuation), 0 = EB-covered (excluded). Always rebuilt with the

--- a/Source/PeleLMeX_Advance.cpp
+++ b/Source/PeleLMeX_Advance.cpp
@@ -99,6 +99,15 @@ PeleLM::Advance(const int is_initIter)
   // Reset fluctuation warnings each time dt could change
   m_warned_clipped_recycle_avg_window_this_step = false;
 
+  // Full-mode recycling needs a valid slab before the first BC fill of the
+  // step; on fresh start or restart, seed it from the current state (the
+  // full-velocity sample requires no history, unlike the running mean).
+  if (
+    m_use_inlet_from_plane != 0 && m_recycling_mode == RecyclingMode::Full &&
+    !m_inlet_recycling.initialized) {
+    updateRecyclingPlaneSnapshot();
+  }
+
   // fillpatch the t^{n} data
   averageDownState(AmrOldTime);
   fillPatchState(AmrOldTime);

--- a/Source/PeleLMeX_BC.cpp
+++ b/Source/PeleLMeX_BC.cpp
@@ -443,6 +443,8 @@ PeleLM::fillpatch_state(
 {
   ProbParm const* lprobparm = prob_parm_d;
   auto const* lpmfdata = pmf_data.device_parm();
+  const int recycFull =
+    static_cast<int>(m_recycling_mode == RecyclingMode::Full);
 
   const int nCompState = (m_incompressible) != 0 ? AMREX_SPACEDIM : NVAR;
 
@@ -504,7 +506,7 @@ PeleLM::fillpatch_state(
         PeleLMCCFillExtDirState<ProblemSpecificFunctions>{
           lprobparm, lpmfdata, m_nAux,
           static_cast<int>(turb_inflow.is_initialized()),
-          m_use_inlet_from_plane, m_inlet_plane_dir, m_map_eval});
+          m_use_inlet_from_plane, m_inlet_plane_dir, recycFull, m_map_eval});
     FillPatchSingleLevel(
       a_state, amrex::IntVect(nGhost), a_time,
       {&(m_leveldata_old[lev]->state), &(m_leveldata_new[lev]->state)},
@@ -524,7 +526,7 @@ PeleLM::fillpatch_state(
         PeleLMCCFillExtDirState<ProblemSpecificFunctions>{
           lprobparm, lpmfdata, m_nAux,
           static_cast<int>(turb_inflow.is_initialized()),
-          m_use_inlet_from_plane, m_inlet_plane_dir, m_map_eval});
+          m_use_inlet_from_plane, m_inlet_plane_dir, recycFull, m_map_eval});
     amrex::PhysBCFunct<
       amrex::GpuBndryFuncFab<PeleLMCCFillExtDirState<ProblemSpecificFunctions>>>
       fine_bndry_func(
@@ -532,7 +534,7 @@ PeleLM::fillpatch_state(
         PeleLMCCFillExtDirState<ProblemSpecificFunctions>{
           lprobparm, lpmfdata, m_nAux,
           static_cast<int>(turb_inflow.is_initialized()),
-          m_use_inlet_from_plane, m_inlet_plane_dir, m_map_eval});
+          m_use_inlet_from_plane, m_inlet_plane_dir, recycFull, m_map_eval});
     FillPatchTwoLevels(
       a_state, amrex::IntVect(nGhost), a_time,
       {&(m_leveldata_old[lev - 1]->state), &(m_leveldata_new[lev - 1]->state)},
@@ -1006,6 +1008,8 @@ PeleLM::fillcoarsepatch_state(
   AMREX_ASSERT(lev > 0);
   ProbParm const* lprobparm = prob_parm_d;
   auto const* lpmfdata = pmf_data.device_parm();
+  const int recycFull =
+    static_cast<int>(m_recycling_mode == RecyclingMode::Full);
 
   const int nCompState = (m_incompressible) != 0 ? AMREX_SPACEDIM : NVAR;
 
@@ -1029,7 +1033,7 @@ PeleLM::fillcoarsepatch_state(
       PeleLMCCFillExtDirState<ProblemSpecificFunctions>{
         lprobparm, lpmfdata, m_nAux,
         static_cast<int>(turb_inflow.is_initialized()), m_use_inlet_from_plane,
-        m_inlet_plane_dir, m_map_eval});
+        m_inlet_plane_dir, recycFull, m_map_eval});
   amrex::PhysBCFunct<
     amrex::GpuBndryFuncFab<PeleLMCCFillExtDirState<ProblemSpecificFunctions>>>
     fine_bndry_func(
@@ -1037,7 +1041,7 @@ PeleLM::fillcoarsepatch_state(
       PeleLMCCFillExtDirState<ProblemSpecificFunctions>{
         lprobparm, lpmfdata, m_nAux,
         static_cast<int>(turb_inflow.is_initialized()), m_use_inlet_from_plane,
-        m_inlet_plane_dir, m_map_eval});
+        m_inlet_plane_dir, recycFull, m_map_eval});
   InterpFromCoarseLevel(
     a_state, amrex::IntVect(nGhost), a_time, m_leveldata_new[lev - 1]->state, 0,
     0, nCompState, geom[lev - 1], geom[lev], crse_bndry_func, 0,
@@ -1207,6 +1211,8 @@ PeleLM::setInflowBoundaryVel(
 
   ProbParm const* lprobparm = prob_parm_d;
   auto const* lpmfdata = pmf_data.device_parm();
+  const int recycFull =
+    static_cast<int>(m_recycling_mode == RecyclingMode::Full);
   amrex::PhysBCFunct<
     amrex::GpuBndryFuncFab<PeleLMCCFillExtDirState<ProblemSpecificFunctions>>>
     bndry_func(
@@ -1214,7 +1220,7 @@ PeleLM::setInflowBoundaryVel(
       PeleLMCCFillExtDirState<ProblemSpecificFunctions>{
         lprobparm, lpmfdata, m_nAux,
         static_cast<int>(turb_inflow.is_initialized()), m_use_inlet_from_plane,
-        m_inlet_plane_dir, m_map_eval});
+        m_inlet_plane_dir, recycFull, m_map_eval});
 
   bndry_func(a_vel, 0, AMREX_SPACEDIM, a_vel.nGrowVect(), time, 0);
 
@@ -1385,6 +1391,8 @@ PeleLM::interpRecyclingSlabFromCoarse(
 
   ProbParm const* lprobparm = prob_parm_d;
   auto const* lpmfdata = pmf_data.device_parm();
+  const int recycFull =
+    static_cast<int>(m_recycling_mode == RecyclingMode::Full);
   // All-int_dir dummy BCRecs disable boundary handling: the slab lies in the
   // domain interior, so PhysBCFunct calls on the temporaries are no-ops in
   // practice. The time argument is likewise informational only.
@@ -1407,7 +1415,7 @@ PeleLM::interpRecyclingSlabFromCoarse(
       PeleLMCCFillExtDirState<ProblemSpecificFunctions>{
         lprobparm, lpmfdata, m_nAux,
         static_cast<int>(turb_inflow.is_initialized()), m_use_inlet_from_plane,
-        m_inlet_plane_dir});
+        m_inlet_plane_dir, recycFull});
   amrex::PhysBCFunct<
     amrex::GpuBndryFuncFab<PeleLMCCFillExtDirState<ProblemSpecificFunctions>>>
     fine_bndry_func(
@@ -1415,7 +1423,7 @@ PeleLM::interpRecyclingSlabFromCoarse(
       PeleLMCCFillExtDirState<ProblemSpecificFunctions>{
         lprobparm, lpmfdata, m_nAux,
         static_cast<int>(turb_inflow.is_initialized()), m_use_inlet_from_plane,
-        m_inlet_plane_dir});
+        m_inlet_plane_dir, recycFull});
   amrex::InterpFromCoarseLevel(
     a_fine, amrex::IntVect(0), m_cur_time, a_crse, 0, 0, AMREX_SPACEDIM,
     geom[lev - 1], geom[lev], crse_bndry_func, 0, fine_bndry_func, 0,
@@ -1665,6 +1673,27 @@ PeleLM::updateRecyclingPlaneSnapshot()
 #endif
   }
 
+  if (m_recycling_mode == RecyclingMode::Full) {
+    // Full-velocity injection: the sampled velocity itself is the boundary
+    // data; no running mean is maintained. fluct_src doubles as the
+    // injection buffer consumed by fillFromRecyclingPlane.
+    for (int lev = 0; lev <= finest_level; ++lev) {
+      if (m_inlet_recycling.u_src[lev] == nullptr) {
+        continue;
+      }
+      amrex::MultiFab::Copy(
+        *m_inlet_recycling.fluct_src[lev], *m_inlet_recycling.u_src[lev], 0, 0,
+        AMREX_SPACEDIM, 0);
+    }
+    if (!m_inlet_recycling.initialized) {
+      m_inlet_recycling.initialized = true;
+      m_inlet_recycling.n_samples = 1;
+    } else {
+      ++m_inlet_recycling.n_samples;
+    }
+    return;
+  }
+
   // Update the running mean and store the current fluctuation.
   // NOTE: m_inlet_recycling.n_samples counts the snapshots accumulated into
   // the running mean; the warmup gate in fillFromRecyclingPlane compares
@@ -1799,9 +1828,13 @@ PeleLM::fillFromRecyclingPlane(amrex::MultiFab& a_vel, int vel_comp, int lev)
   }
 
   // Don't inject anything until the running mean has had a chance to settle.
+  // The warmup gate applies only to fluctuations mode: a full-velocity
+  // sample is valid from the first snapshot, so full mode injects as soon
+  // as the buffer is seeded.
   if (
     !m_inlet_recycling.initialized ||
-    m_inlet_recycling.n_samples <= m_inlet_plane_warmup_steps) {
+    (m_recycling_mode == RecyclingMode::Fluctuations &&
+     m_inlet_recycling.n_samples <= m_inlet_plane_warmup_steps)) {
     set_zero_in_bndry = true;
   }
 

--- a/Source/PeleLMeX_BCfill.H
+++ b/Source/PeleLMeX_BCfill.H
@@ -65,6 +65,10 @@ struct PeleLMCCFillExtDirState
   MeshMapEvaluator m_map_eval{}; // defaults to Identity (no mesh mapping)
   int m_do_inlet_from_plane = 0;
   int m_inlet_from_plane_dir = -1;
+  // When != 0 (peleLM.recycling_mode = full), the pre-loaded ghost value on
+  // the recycling face is the complete inflow velocity and is preserved
+  // against whatever bcnormal writes to the velocity components there.
+  int m_recycling_full = 0;
 
   AMREX_GPU_HOST
   constexpr PeleLMCCFillExtDirState(
@@ -74,6 +78,7 @@ struct PeleLMCCFillExtDirState
     int do_turbInflow,
     int do_inletFromPlane,
     int inlet_plane_dir,
+    int recycling_full,
     MeshMapEvaluator a_map_eval = MeshMapEvaluator{})
     : lprobparm(a_prob_parm),
       lpmfdata(a_pmf_data),
@@ -81,7 +86,8 @@ struct PeleLMCCFillExtDirState
       m_do_turbInflow(do_turbInflow),
       m_map_eval(a_map_eval),
       m_do_inlet_from_plane(do_inletFromPlane),
-      m_inlet_from_plane_dir(inlet_plane_dir)
+      m_inlet_from_plane_dir(inlet_plane_dir),
+      m_recycling_full(recycling_full)
   {
   }
 
@@ -127,7 +133,10 @@ struct PeleLMCCFillExtDirState
           const auto s_in = state.cellData(iv_in[0], iv_in[1], iv_in[2]);
 
           // If using TurbInflow or inlet_from_plane, pass in the sampled data.
-          // User can overwrite or increment, as needed
+          // User can overwrite or increment, as needed. In full recycling
+          // mode the pre-loaded value is the complete inflow velocity and is
+          // kept regardless of what bcnormal does to it.
+          bool keep_recycled = false;
           if (n >= VELX && n < DENSITY) {
             if (
               m_do_turbInflow != 0 || ((m_do_inlet_from_plane != 0) &&
@@ -136,6 +145,9 @@ struct PeleLMCCFillExtDirState
                     state(iv, VELX + n))) { // During fillcoarsepatch, get here
                                             // with nan. TODO: find a better fix
                 s_ext[VELX + n] = state(iv, VELX + n);
+                keep_recycled = (m_recycling_full != 0) &&
+                                (m_do_inlet_from_plane != 0) &&
+                                (idir == m_inlet_from_plane_dir);
               } else {
                 s_ext[VELX + n] = 0;
               }
@@ -145,7 +157,9 @@ struct PeleLMCCFillExtDirState
           // /Exec
           T::bcnormal(
             x, s_in, s_ext, idir, 1, time, geom, *lprobparm, lpmfdata);
-          state(iv, n) = s_ext[n];
+          if (!keep_recycled) {
+            state(iv, n) = s_ext[n];
+          }
         }
       }
 
@@ -171,7 +185,10 @@ struct PeleLMCCFillExtDirState
           const auto s_in = state.cellData(iv_in[0], iv_in[1], iv_in[2]);
 
           // If using TurbInflow or inlet_from_plane, pass in the sampled data.
-          // User can overwrite or increment, as needed
+          // User can overwrite or increment, as needed. In full recycling
+          // mode the pre-loaded value is the complete inflow velocity and is
+          // kept regardless of what bcnormal does to it.
+          bool keep_recycled = false;
           if (n >= VELX && n < DENSITY) {
             if (
               m_do_turbInflow != 0 || ((m_do_inlet_from_plane != 0) &&
@@ -180,6 +197,9 @@ struct PeleLMCCFillExtDirState
                     state(iv, VELX + n))) { // During fillcoarsepatch, get here
                                             // with nan. TODO: find a better fix
                 s_ext[VELX + n] = state(iv, VELX + n);
+                keep_recycled = (m_recycling_full != 0) &&
+                                (m_do_inlet_from_plane != 0) &&
+                                (idir == m_inlet_from_plane_dir);
               } else {
                 s_ext[VELX + n] = 0;
               }
@@ -189,7 +209,9 @@ struct PeleLMCCFillExtDirState
           // /Exec
           T::bcnormal(
             x, s_in, s_ext, idir, -1, time, geom, *lprobparm, lpmfdata);
-          state(iv, n) = s_ext[n];
+          if (!keep_recycled) {
+            state(iv, n) = s_ext[n];
+          }
         }
       }
     }

--- a/Source/PeleLMeX_Init.cpp
+++ b/Source/PeleLMeX_Init.cpp
@@ -274,6 +274,17 @@ PeleLM::initData()
     }
 
     //----------------------------------------------------------------
+    // Full-mode recycling injects the sampled velocity itself, so the slab
+    // can (and should) be seeded from the initial solution before the init
+    // projections and iterations consume inflow BCs. Fluctuations mode
+    // seeds at the end of the first step once a mean can accumulate.
+    if (
+      m_use_inlet_from_plane != 0 && m_recycling_mode == RecyclingMode::Full &&
+      !m_inlet_recycling.initialized) {
+      updateRecyclingPlaneSnapshot();
+    }
+
+    //----------------------------------------------------------------
     // Project initial solution
     projectInitSolution();
 
@@ -372,6 +383,15 @@ PeleLM::initData()
     m_resetCoveredMask = 1;
     resetCoveredMask();
     updateDiagnostics();
+
+    // Full-mode recycling carries no checkpointed state; seed the slab
+    // from the restored solution so the first step's BC fills see the
+    // recycled velocity (see the matching call in the fresh-start path).
+    if (
+      m_use_inlet_from_plane != 0 && m_recycling_mode == RecyclingMode::Full &&
+      !m_inlet_recycling.initialized) {
+      updateRecyclingPlaneSnapshot();
+    }
 
     // Active control
     constexpr int is_restart = 1;

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -779,8 +779,13 @@ PeleLM::WriteHeader(const std::string& name, const bool is_checkpoint) const
     // samples were available for that level yet; older checkpoints without
     // the marker remain readable because the restart code treats the absence
     // of the marker as "inactive".
+    // Only fluctuations mode carries restart state (the running mean); in
+    // full mode the injection buffer reseeds from the first post-restart
+    // snapshot and nothing needs to be checkpointed.
     const bool recycling_active =
-      (m_use_inlet_from_plane != 0) && m_inlet_recycling.initialized &&
+      (m_use_inlet_from_plane != 0) &&
+      (m_recycling_mode == RecyclingMode::Fluctuations) &&
+      m_inlet_recycling.initialized &&
       static_cast<int>(m_inlet_recycling.mean_src.size()) >= finest_level + 1;
     if ((m_use_inlet_from_plane != 0) && recycling_active) {
       HeaderFile << "RecyclingPlane: " << "\n";
@@ -868,9 +873,12 @@ PeleLM::WriteCheckPointFile()
       }
     }
 
-    // Per-level recycling-plane running mean (only when active and seeded).
+    // Per-level recycling-plane running mean (only when active and seeded;
+    // fluctuations mode only, matching the header block in WriteHeader).
     if (
-      (m_use_inlet_from_plane != 0) && m_inlet_recycling.initialized &&
+      (m_use_inlet_from_plane != 0) &&
+      (m_recycling_mode == RecyclingMode::Fluctuations) &&
+      m_inlet_recycling.initialized &&
       lev < static_cast<int>(m_inlet_recycling.mean_src.size()) &&
       m_inlet_recycling.mean_src[lev]) {
       amrex::VisMF::Write(
@@ -1138,7 +1146,10 @@ PeleLM::ReadCheckPointFile()
   // temporary MultiFab (built with the on-disk BoxArray) into the rebuilt
   // slab (which uses the current run's maxGridSize), so a maxGridSize change
   // between the original run and the restart is handled transparently.
-  if (have_recycling_chk && (m_use_inlet_from_plane != 0)) {
+  const bool recycling_fluct_active =
+    (m_use_inlet_from_plane != 0) &&
+    (m_recycling_mode == RecyclingMode::Fluctuations);
+  if (have_recycling_chk && recycling_fluct_active) {
     buildRecyclingPlaneStorage();
     for (int lev = 0; lev <= finest_level; ++lev) {
       if (
@@ -1174,7 +1185,14 @@ PeleLM::ReadCheckPointFile()
       << "WARNING: Restart checkpoint contains RecyclingPlane data, but "
       << "peleLM.use_inlet_from_plane = 0 in this run. Ignoring checkpointed "
       << "recycling-plane running mean.\n";
-  } else if ((!have_recycling_chk) && (m_use_inlet_from_plane != 0)) {
+  } else if (have_recycling_chk) {
+    // use_inlet_from_plane != 0 but recycling_mode = full: the mean belongs
+    // to fluctuations mode and full mode needs no restored state (the
+    // injection buffer reseeds from the first post-restart snapshot).
+    amrex::Print()
+      << "WARNING: peleLM.recycling_mode = full; ignoring the checkpointed "
+      << "recycling-plane running mean.\n";
+  } else if ((!have_recycling_chk) && recycling_fluct_active) {
     amrex::Print()
       << "WARNING: peleLM.use_inlet_from_plane != 0 in this run, but the "
       << "restart checkpoint does not contain RecyclingPlane data. "

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -369,6 +369,34 @@ PeleLM::readParameters()
       m_inlet_plane_warmup_steps >= 0,
       "peleLM.inlet_plane_warmup_steps must be non-negative when "
       "peleLM.use_inlet_from_plane is enabled");
+
+    std::string recycling_mode = "fluctuations";
+    pp.query("recycling_mode", recycling_mode);
+    if (recycling_mode == "fluctuations") {
+      m_recycling_mode = RecyclingMode::Fluctuations;
+    } else if (recycling_mode == "full") {
+      m_recycling_mode = RecyclingMode::Full;
+    } else {
+      amrex::Abort(
+        "peleLM.recycling_mode must be 'fluctuations' or 'full', got '" +
+        recycling_mode + "'");
+    }
+    if (m_recycling_mode == RecyclingMode::Full) {
+      // These controls belong to the running-mean machinery and have no
+      // effect in full mode.
+      if (m_inlet_plane_warmup_steps > 0) {
+        amrex::Print()
+          << "WARNING: peleLM.inlet_plane_warmup_steps is ignored when "
+             "peleLM.recycling_mode = full; injection begins with the "
+             "first snapshot.\n";
+      }
+      if (m_inlet_plane_avg_window > 0.0) {
+        amrex::Print()
+          << "WARNING: peleLM.inlet_plane_avg_window is ignored when "
+             "peleLM.recycling_mode = full; no running mean is "
+             "maintained.\n";
+      }
+    }
   }
 
 #ifdef PELE_USE_PLASMA


### PR DESCRIPTION
Adds an alternative injection mode for the recycling-plane inflow:

peleLM.recycling_mode = fluctuations (default) | full

fluctuations is the existing behavior (zero-mean fluctuation about a running mean, added to the bcnormal profile). full injects the entire sampled velocity with no mean management.

Implementation reuses the existing machinery wholesale: fluct_src acts as a generic injection buffer, and in full mode updateRecyclingPlaneSnapshot copies u_src into it and skips the mean/fluctuation arithmetic. The multilevel interp cascade, copy-on-intersect, EB masking, regrid rebuild, and fillFromRecyclingPlane are unchanged. Full mode is stateless, so the slab is seeded eagerly (fresh start, restart, and a guard at the top of Advance) and valid data exists for the very first BC fill; checkpoints carry the running mean only in fluctuations mode; the warmup and averaging-window controls apply only to fluctuations mode (setup warnings if set with full).

The recycled velocity is enforced by the boundary-fill machinery itself: the mode is threaded into PeleLMCCFillExtDirState as a plain int member, and **velocity writes from bcnormal are ignored on the recycling face in full mode** — problem setups run unmodified in either mode, with no double-counting of the mean profile. Documented in LMeXControls and the BFS recycling tutorial.

Testing: default mode changes no answers, so the CI reference comparison is expected to pass.