### PR TITLE
Option to coarsen base level when restarting from plt file

### DIFF
--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -133,7 +133,8 @@ IO parameters
     peleLM.initDataPlt_reset_time = 1      # [OPT, DEF=1] Resets time and nsteps to 0 after restarting from a plot file. (Warning: plot file will be rewritten if not renamed and argument value = 0)
     peleLM.initDataPlt_coarsen = 0         # [OPT, DEF=0] Enable restarting from plotfile with 2x coarser base mesh (non-EB only). Uses multi-level mapping.
     peleLM.initDataPlt_specname_map = spec1 spec2 # [OPT, DEF=""] If specified, lookup these entries instead of species names when populating species from the init plot file (length must match NUM_SPECIES)
-    peleLM.initDataPlt_patch_flow_variables = false # [OPT, DEF=false] Enable user-defined flow variable patching after reading a plot solution file    amr.regrid_on_restart = 1              # [OPT, DEF="0"] Trigger a regrid after the data from checkpoint are loaded
+    peleLM.initDataPlt_patch_flow_variables = false # [OPT, DEF=false] Enable user-defined flow variable patching after reading a plot solution file
+    amr.regrid_on_restart = 1              # [OPT, DEF="0"] Trigger a regrid after the data from checkpoint are loaded
     amr.n_files          = 64              # [OPT, DEF="min(256,NProcs)"] Number of files to write per level
 
 Refinement controls

--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -130,10 +130,10 @@ IO parameters
 
     amr.restart          = chk00100        # [OPT, DEF=""] Checkpoint from which to restart the simulation
     amr.initDataPlt      = plt01000        # [OPT, DEF=""] Provide a plotfile from which to extract initial data
-    peleLM.initDataPlt_reset_time = 1               # [OPT, DEF=1] Resets time and nsteps to 0 after restarting from a plot file. (Warning: plot file will be rewritten if not renamed and argument value = 0)
+    peleLM.initDataPlt_reset_time = 1      # [OPT, DEF=1] Resets time and nsteps to 0 after restarting from a plot file. (Warning: plot file will be rewritten if not renamed and argument value = 0)
+    peleLM.initDataPlt_coarsen = 0         # [OPT, DEF=0] Enable restarting from plotfile with a coarser base mesh for non-EB cases. Supports 2x, 4x, or 8x coarsening with multi-level mapping.
     peleLM.initDataPlt_specname_map = spec1 spec2 # [OPT, DEF=""] If specified, lookup these entries instead of species names when populating species from the init plot file (length must match NUM_SPECIES)
-    peleLM.initDataPlt_patch_flow_variables = false # [OPT, DEF=false] Enable user-defined flow variable patching after reading a plot solution file
-    amr.regrid_on_restart = 1              # [OPT, DEF="0"] Trigger a regrid after the data from checkpoint are loaded
+    peleLM.initDataPlt_patch_flow_variables = false # [OPT, DEF=false] Enable user-defined flow variable patching after reading a plot solution file    amr.regrid_on_restart = 1              # [OPT, DEF="0"] Trigger a regrid after the data from checkpoint are loaded
     amr.n_files          = 64              # [OPT, DEF="min(256,NProcs)"] Number of files to write per level
 
 Refinement controls

--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -131,7 +131,7 @@ IO parameters
     amr.restart          = chk00100        # [OPT, DEF=""] Checkpoint from which to restart the simulation
     amr.initDataPlt      = plt01000        # [OPT, DEF=""] Provide a plotfile from which to extract initial data
     peleLM.initDataPlt_reset_time = 1      # [OPT, DEF=1] Resets time and nsteps to 0 after restarting from a plot file. (Warning: plot file will be rewritten if not renamed and argument value = 0)
-    peleLM.initDataPlt_coarsen = 0         # [OPT, DEF=0] Enable restarting from plotfile with a coarser base mesh for non-EB cases. Supports 2x, 4x, or 8x coarsening with multi-level mapping.
+    peleLM.initDataPlt_coarsen = 0         # [OPT, DEF=0] Enable restarting from plotfile with 2x coarser base mesh (non-EB only). Uses multi-level mapping.
     peleLM.initDataPlt_specname_map = spec1 spec2 # [OPT, DEF=""] If specified, lookup these entries instead of species names when populating species from the init plot file (length must match NUM_SPECIES)
     peleLM.initDataPlt_patch_flow_variables = false # [OPT, DEF=false] Enable user-defined flow variable patching after reading a plot solution file    amr.regrid_on_restart = 1              # [OPT, DEF="0"] Trigger a regrid after the data from checkpoint are loaded
     amr.n_files          = 64              # [OPT, DEF="min(256,NProcs)"] Number of files to write per level

--- a/Exec/RegTests/HotBubble/input.2d-regt-coarsen-restart
+++ b/Exec/RegTests/HotBubble/input.2d-regt-coarsen-restart
@@ -1,3 +1,8 @@
+# Test restarting from a plt file with a coarser base mesh
+# This uses a wider domain than the original input.2d-regt and a fixed dt
+# 1. Run this input file using minor tweaks to input.2d-regt to generate plt00500
+# 2. Uncomment the lines below to restart from plt00500 with a coarser base mesh
+
 FILE = input.2d-regt
 
 # Larger domain than the original to allow for a coarser base mesh later
@@ -22,11 +27,14 @@ amr.stop_time = 0.15
 amr.fixed_dt = 0.0002
 amr.cfl = -1
 
-## Uncomment to restart from plt with 2x coarser base mesh
-## Original plt has 64x64 base with amr.max_level = 3 
-## New base is 32x32 with amr.max_level = 4
-## With level shift, plotfile L0 becomes new L1, plt L1->new L2, plt L2->new L3
-#
+# ------------------------------------------------------------------
+# TEST RESTART FROM PLOTFILE WITH COARSER BASE MESH
+# ------------------------------------------------------------------
+# Uncomment lines below to restart from plt with 2x coarser base mesh
+# Original plt has 64x64 base with amr.max_level = 3 
+# New base is 32x32 with amr.max_level = 4
+# plt file L0 becomes new L1, plt L1->new L2, plt L2->new L3
+
 #amr.plot_file = pltCoarse
 #amr.initDataPlt = plt00500             # Plotfile to restart from
 #peleLM.initDataPlt_coarsen = 1          # Enable multi-level coarsening

--- a/Exec/RegTests/HotBubble/input.2d-regt-coarsen-restart
+++ b/Exec/RegTests/HotBubble/input.2d-regt-coarsen-restart
@@ -24,7 +24,7 @@ amr.cfl = -1
 
 ## Uncomment to restart from plt with 2x coarser base mesh
 ## Original plt has 64x64 base with amr.max_level = 3 
-## New base is 32x32 with amr.max_level =4
+## New base is 32x32 with amr.max_level = 4
 ## With level shift, plotfile L0 becomes new L1, plt L1->new L2, plt L2->new L3
 #
 #amr.plot_file = pltCoarse

--- a/Exec/RegTests/HotBubble/input.2d-regt-coarsen-restart
+++ b/Exec/RegTests/HotBubble/input.2d-regt-coarsen-restart
@@ -41,7 +41,7 @@ amr.cfl = -1
 #peleLM.initDataPlt_reset_time = 0 
 #
 ##-------------------------AMR CONTROL----------------------------
-#amr.n_cell          = 32 32 16        # Level 0 number of cells (2x coarser than original)
+#amr.n_cell          = 32 32           # Level 0 number of cells (2x coarser than original)
 #amr.max_level       = 4               # Increased from 3 to handle level shift           
 #amr.stop_time       = 0.15
 #

--- a/Exec/RegTests/HotBubble/input.2d-regt-coarsen-restart
+++ b/Exec/RegTests/HotBubble/input.2d-regt-coarsen-restart
@@ -1,0 +1,42 @@
+FILE = input.2d-regt
+
+# Larger domain than the original to allow for a coarser base mesh later
+geometry.prob_lo     = 0.0 0.0 0.0        # x_lo y_lo (z_lo)
+geometry.prob_hi     = 0.032 0.032 0.016        # x_hi y_hi (z_hi)
+
+#-------------------------AMR CONTROL----------------------------
+amr.n_cell          = 64 64         # Level 0 number of cells in each direction   
+amr.max_level       = 3             # maximum level number allowed
+amr.ref_ratio       = 2 2 2 2       # refinement ratio
+amr.regrid_int      = 5             # how often to regrid
+amr.n_error_buf     = 1 1 1 1       # number of buffer cells in error est
+amr.grid_eff        = 0.95          # what constitutes an efficient grid
+amr.blocking_factor = 8             # block factor in grid generation (min box size)
+amr.max_grid_size   = 32            # max box size
+
+#-------------------------PeleLM CONTROL----------------------------
+amr.plot_int = 50
+amr.max_step = 1000
+amr.dt_shrink = 1
+amr.stop_time = 0.15
+amr.fixed_dt = 0.0002
+amr.cfl = -1
+
+## Uncomment to restart from plt with 2x coarser base mesh
+## Original plt has 64x64 base with amr.max_level = 3 
+## New base is 32x32 with amr.max_level =4
+## With level shift, plotfile L0 becomes new L1, plt L1->new L2, plt L2->new L3
+#
+#amr.plot_file = pltCoarse
+#amr.initDataPlt = plt00500             # Plotfile to restart from
+#peleLM.intDataPlt_coarsen = 1          # Enable multi-level coarsening
+#peleLM.initDataPlt_reset_time = 0 
+#
+##-------------------------AMR CONTROL----------------------------
+#amr.n_cell          = 32 32 16        # Level 0 number of cells (2x coarser than original)
+#amr.max_level       = 4               # Increased from 3 to handle level shift           
+#amr.stop_time       = 0.15
+#
+##--------------------REFINEMENT CONTROL------------------------
+#amr.temp.max_level     = 3
+#amr.gtemp.max_level    = 4

--- a/Exec/RegTests/HotBubble/input.2d-regt-coarsen-restart
+++ b/Exec/RegTests/HotBubble/input.2d-regt-coarsen-restart
@@ -29,7 +29,7 @@ amr.cfl = -1
 #
 #amr.plot_file = pltCoarse
 #amr.initDataPlt = plt00500             # Plotfile to restart from
-#peleLM.intDataPlt_coarsen = 1          # Enable multi-level coarsening
+#peleLM.initDataPlt_coarsen = 1          # Enable multi-level coarsening
 #peleLM.initDataPlt_reset_time = 0 
 #
 ##-------------------------AMR CONTROL----------------------------

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -331,6 +331,26 @@ public:
   void initLevelDataFromPlt(const int a_lev, const std::string& a_dataPltFile);
 
   /**
+   * \brief Compute level shift for multi-level mapping
+   * when coarsening from plotfile. Returns log2(coarsening_ratio).
+   * \param pltData reference to PltFileManager
+   * \return level shift (0 if no coarsening, 1 for 2x, 2 for 4x, etc.)
+   */
+  int computeLevelShift(
+    pele::physics::pltfilemanager::PltFileManager& pltData);
+
+  /**
+   * \brief Coarsen level data from plotfile using conservative averaging
+   * \param a_lev target level index
+   * \param pltData reference to PltFileManager  
+   * \param coarsen_ratio refinement ratio for coarsening
+   */
+  void coarsenLevelFromPlt(
+    const int a_lev,
+    pele::physics::pltfilemanager::PltFileManager& pltData,
+    const amrex::IntVect& coarsen_ratio);
+
+  /**
    * \brief Adds the velocity level data to state
    * data using the velocities from a pltfile
    * \param a_velPltFile path to PeleLMeX plot file
@@ -2150,6 +2170,8 @@ public:
   bool m_write_hdf5_pltfile = false;
   bool m_do_patch_flow_variables = false;
   amrex::Vector<std::string> m_initDataPlt_specname_map = {};
+  bool m_intDataPlt_coarsen = false;
+  int m_level_shift = 0;
 
   //-----------------------------------------------------------------------------
   // ALGORITHM

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -2170,7 +2170,7 @@ public:
   bool m_write_hdf5_pltfile = false;
   bool m_do_patch_flow_variables = false;
   amrex::Vector<std::string> m_initDataPlt_specname_map = {};
-  bool m_intDataPlt_coarsen = false;
+  bool m_initDataPlt_coarsen = false;
   int m_level_shift = 0;
 
   //-----------------------------------------------------------------------------

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -336,13 +336,12 @@ public:
    * \param pltData reference to PltFileManager
    * \return level shift (0 if no coarsening, 1 for 2x, 2 for 4x, etc.)
    */
-  int computeLevelShift(
-    pele::physics::pltfilemanager::PltFileManager& pltData);
+  int computeLevelShift(pele::physics::pltfilemanager::PltFileManager& pltData);
 
   /**
    * \brief Coarsen level data from plotfile using conservative averaging
    * \param a_lev target level index
-   * \param pltData reference to PltFileManager  
+   * \param pltData reference to PltFileManager
    * \param coarsen_ratio refinement ratio for coarsening
    */
   void coarsenLevelFromPlt(

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -331,10 +331,10 @@ public:
   void initLevelDataFromPlt(const int a_lev, const std::string& a_dataPltFile);
 
   /**
-   * \brief Compute level shift for multi-level mapping
-   * when coarsening from plotfile. Returns log2(coarsening_ratio).
+   * \brief Compute level shift for multi-level mapping when coarsening from a
+   * plotfile. Currently only supports 2x coarsening and returns 1 when enabled.
    * \param pltData reference to PltFileManager
-   * \return level shift (0 if no coarsening, 1 for 2x, 2 for 4x, etc.)
+   * \return level shift (0 if no coarsening, 1 for 2x)
    */
   int computeLevelShift(pele::physics::pltfilemanager::PltFileManager& pltData);
 

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -336,12 +336,13 @@ public:
    * \param pltData reference to PltFileManager
    * \return level shift (0 if no coarsening, 1 for 2x, 2 for 4x, etc.)
    */
-  int computeLevelShift(pele::physics::pltfilemanager::PltFileManager& pltData);
+  int computeLevelShift(
+    pele::physics::pltfilemanager::PltFileManager& pltData);
 
   /**
    * \brief Coarsen level data from plotfile using conservative averaging
    * \param a_lev target level index
-   * \param pltData reference to PltFileManager
+   * \param pltData reference to PltFileManager  
    * \param coarsen_ratio refinement ratio for coarsening
    */
   void coarsenLevelFromPlt(

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -1242,47 +1242,49 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
   }
   auto& pltData = *pltDataPtr;
   amrex::Vector<std::string> plt_vars = pltData.getVariableList();
-
+  
   // Track whether we coarsened the base level (for skip_plt_fill logic later)
   bool did_coarsen_base = false;
-
+  
   // Handle multi-level coarsening with peleLM.initDataPlt_coarsen
   if (m_initDataPlt_coarsen) {
     // Compute level shift once at level 0
     if (a_lev == 0) {
       m_level_shift = computeLevelShift(pltData);
-
+      
       if (m_level_shift > 0) {
-        amrex::Print()
-          << "  peleLM.initDataPlt_coarsen: Level mapping active (shift="
+        amrex::Print() 
+          << "  peleLM.initDataPlt_coarsen: Level mapping active (shift=" 
           << m_level_shift << ")\n";
-        amrex::Print() << "  Plotfile level K will become new level K+"
-                       << m_level_shift << "\n";
-
+        amrex::Print() 
+          << "  Plotfile level K will become new level K+" 
+          << m_level_shift << "\n";
+        
         // Verify we have enough plotfile levels
         int max_plt_lev = pltData.getNlev() - 1;
         int max_new_lev = finest_level;
         int min_required_plt_lev = max_new_lev - m_level_shift;
-
+        
         if (min_required_plt_lev > max_plt_lev) {
           amrex::Abort(
             "peleLM.initDataPlt_coarsen: Insufficient plotfile levels. "
-            "Need plotfile level " +
-            std::to_string(min_required_plt_lev) + " but plotfile only has " +
-            std::to_string(max_plt_lev) + " levels.");
+            "Need plotfile level " + std::to_string(min_required_plt_lev) +
+            " but plotfile only has " + std::to_string(max_plt_lev) + " levels.");
         }
       }
     }
-
+    
     // Determine source plotfile level for current AMR level
     int source_plt_level = a_lev - m_level_shift;
-
+    
     // Coarsen from plotfile level 0 to new coarser level 0
     // Must check this first, since a_lev==0 gives source_plt_level < 0
     if (a_lev == 0 && m_level_shift > 0) {
-      amrex::IntVect coarsen_ratio = amrex::IntVect(AMREX_D_DECL(
-        1 << m_level_shift, 1 << m_level_shift, 1 << m_level_shift));
-
+      amrex::IntVect coarsen_ratio = 
+        amrex::IntVect(AMREX_D_DECL(1 << m_level_shift, 
+                                     1 << m_level_shift, 
+                                     1 << m_level_shift));
+      
       // coarsenLevelFromPlt fills ldata_p->state directly
       coarsenLevelFromPlt(a_lev, pltData, coarsen_ratio);
       did_coarsen_base = true;
@@ -1292,16 +1294,16 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
     // from coarser level
     else if (source_plt_level < 0) {
       if (m_verbose > 0) {
-        amrex::Print() << "  Level " << a_lev
-                       << " (intermediate): Interpolating from level "
-                       << (a_lev - 1) << "\n";
-        amrex::Print()
+        amrex::Print() 
+          << "  Level " << a_lev << " (intermediate): Interpolating from level " 
+          << (a_lev - 1) << "\n";
+        amrex::Print() 
           << "  (Will be refined by regridding based on tagging criteria)\n";
       }
-
+      
       // Get level data
       auto* ldata_p = getLevelDataPtr(a_lev, AmrNewTime);
-
+      
       // Interpolate all state components from level a_lev-1
       // Use fillcoarsepatch which does conservative interpolation
       fillcoarsepatch_state(a_lev, m_cur_time, ldata_p->state, 0);
@@ -1309,7 +1311,7 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
       return;
     }
   }
-
+  
   if (m_do_reset_time == 0) {
     m_cur_time = pltData.getTime();
     m_nstep = pltData.getNsteps();
@@ -1385,14 +1387,12 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
   // Get level data
   auto* ldata_p = getLevelDataPtr(a_lev, AmrNewTime);
 
-  // Determine if we need to fill from plotfile or if already filled by
-  // coarsening
+  // Determine if we need to fill from plotfile or if already filled by coarsening
   bool skip_plt_fill = false;
   int source_plt_level = a_lev; // Default: no level shift
-
+  
   if (m_initDataPlt_coarsen && m_level_shift > 0) {
-    // Coarser level 0 was already handled - data was filled by
-    // coarsenLevelFromPlt
+    // Coarser level 0 was already handled - data was filled by coarsenLevelFromPlt
     if (did_coarsen_base) {
       skip_plt_fill = true;
       if (m_verbose > 0) {
@@ -1402,9 +1402,9 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
       source_plt_level = a_lev - m_level_shift;
       // Direct mapping with level shift
       if (source_plt_level >= 0 && m_verbose > 0) {
-        amrex::Print() << "  Level " << a_lev
-                       << ": Reading from plotfile level " << source_plt_level
-                       << "\n";
+        amrex::Print() 
+          << "  Level " << a_lev << ": Reading from plotfile level " 
+          << source_plt_level << "\n";
       }
     }
   }
@@ -1415,122 +1415,115 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
       source_plt_level, geom[a_lev], idV, VELX, AMREX_SPACEDIM, ldata_p->state);
 
     // Temperature
-    pltData.fillPatchFromPlt(
-      source_plt_level, geom[a_lev], idT, TEMP, 1, ldata_p->state);
+    pltData.fillPatchFromPlt(source_plt_level, geom[a_lev], idT, TEMP, 1, ldata_p->state);
 
     // Species
     // Hold the species in temporary MF before copying to level data
     // in case the number of species differs.
     amrex::MultiFab speciesPlt(grids[a_lev], dmap[a_lev], nSpecPlt, 0);
-    pltData.fillPatchFromPlt(
-      source_plt_level, geom[a_lev], idY, 0, nSpecPlt, speciesPlt);
-    for (int i = 0; i < NUM_SPECIES; ++i) {
-      std::string specName = "Y(" + spec_names[i] + ")";
-      std::string specString = specName;
-      if (!m_initDataPlt_specname_map.empty()) {
-        specString = m_initDataPlt_specname_map[i];
+    pltData.fillPatchFromPlt(source_plt_level, geom[a_lev], idY, 0, nSpecPlt, speciesPlt);
+  for (int i = 0; i < NUM_SPECIES; ++i) {
+    std::string specName = "Y(" + spec_names[i] + ")";
+    std::string specString = specName;
+    if (!m_initDataPlt_specname_map.empty()) {
+      specString = m_initDataPlt_specname_map[i];
+    }
+    int foundSpec = 0;
+    for (int iplt = 0; iplt < nSpecPlt; ++iplt) {
+      if (specString == plt_vars[idY + iplt]) {
+        amrex::MultiFab::Copy(
+          ldata_p->state, speciesPlt, iplt, FIRSTSPEC + i, 1, 0);
+        foundSpec = 1;
+        if (m_verbose > 0) {
+          amrex::Print() << "Loading species " << specName
+                         << " from plotfile species " << specString << "\n";
+        }
       }
-      int foundSpec = 0;
-      for (int iplt = 0; iplt < nSpecPlt; ++iplt) {
-        if (specString == plt_vars[idY + iplt]) {
-          amrex::MultiFab::Copy(
-            ldata_p->state, speciesPlt, iplt, FIRSTSPEC + i, 1, 0);
+    }
+    if (foundSpec == 0) {
+      for (int iplt = 0; iplt < plt_vars.size(); ++iplt) {
+        if (specString == plt_vars[iplt]) {
           foundSpec = 1;
           if (m_verbose > 0) {
             amrex::Print() << "Loading species " << specName
-                           << " from plotfile species " << specString << "\n";
+                           << " from plotfile entry " << specString << "\n";
           }
-        }
-      }
-      if (foundSpec == 0) {
-        for (int iplt = 0; iplt < plt_vars.size(); ++iplt) {
-          if (specString == plt_vars[iplt]) {
-            foundSpec = 1;
-            if (m_verbose > 0) {
-              amrex::Print() << "Loading species " << specName
-                             << " from plotfile entry " << specString << "\n";
-            }
-            pltData.fillPatchFromPlt(
-              source_plt_level, geom[a_lev], iplt, FIRSTSPEC + i, 1,
-              ldata_p->state);
-          }
-        }
-      }
-      if (foundSpec == 0) {
-        ldata_p->state.setVal(0.0, FIRSTSPEC + i, 1);
-        if (m_verbose > 0) {
-          amrex::Print() << "For species " << specName << " entry "
-                         << specString
-                         << " not found in plot file, setting to 0\n";
+          pltData.fillPatchFromPlt(
+            source_plt_level, geom[a_lev], iplt, FIRSTSPEC + i, 1, ldata_p->state);
         }
       }
     }
+    if (foundSpec == 0) {
+      ldata_p->state.setVal(0.0, FIRSTSPEC + i, 1);
+      if (m_verbose > 0) {
+        amrex::Print() << "For species " << specName << " entry " << specString
+                       << " not found in plot file, setting to 0\n";
+      }
+    }
+  }
 
-    // Converting units when pltfile is coming from PeleC solution
-    if (pltfileSource == "C") {
-      amrex::Print() << " Converting CGS to MKS units... \n";
-      auto const& state_ma = ldata_p->state.arrays();
-      amrex::ParallelFor(
-        ldata_p->state, amrex::IntVect(0), AMREX_SPACEDIM,
-        [state_ma] AMREX_GPU_DEVICE(
-          int box_no, int i, int j, int k, int n) noexcept {
-          amrex::Array4<amrex::Real> vel(state_ma[box_no], VELX);
-          vel(i, j, k, n) *= 0.01;
-        });
-      amrex::Gpu::streamSynchronize();
-    }
+  // Converting units when pltfile is coming from PeleC solution
+  if (pltfileSource == "C") {
+    amrex::Print() << " Converting CGS to MKS units... \n";
+    auto const& state_ma = ldata_p->state.arrays();
+    amrex::ParallelFor(
+      ldata_p->state, amrex::IntVect(0), AMREX_SPACEDIM,
+      [state_ma] AMREX_GPU_DEVICE(
+        int box_no, int i, int j, int k, int n) noexcept {
+        amrex::Array4<amrex::Real> vel(state_ma[box_no], VELX);
+        vel(i, j, k, n) *= 0.01;
+      });
+    amrex::Gpu::streamSynchronize();
+  }
 
 #ifdef PELE_USE_PLASMA
     // nE
-    pltData.fillPatchFromPlt(
-      source_plt_level, geom[a_lev], inE, NE, 1, ldata_p->state);
+    pltData.fillPatchFromPlt(source_plt_level, geom[a_lev], inE, NE, 1, ldata_p->state);
     // phiV
-    pltData.fillPatchFromPlt(
-      source_plt_level, geom[a_lev], iPhiV, PHIV, 1, ldata_p->state);
+    pltData.fillPatchFromPlt(source_plt_level, geom[a_lev], iPhiV, PHIV, 1, ldata_p->state);
 #endif
 #ifdef PELE_USE_SOOT
     if (do_soot_solve) {
       if (inSoot >= 0) {
         pltData.fillPatchFromPlt(
-          source_plt_level, geom[a_lev], inSoot, FIRSTSOOT, NUMSOOTVAR,
-          ldata_p->state);
-        if (pltfileSource == "C") {
-          SootConst sc;
-          amrex::Real* momV = sc.MomOrderV.data();
-          amrex::Real* momS = sc.MomOrderS.data();
-          auto const& state_ma = ldata_p->state.arrays();
-          amrex::Real soot_exp[NUM_SOOT_MOMENTS] = {0.0};
-          for (int n = 0; n < NUM_SOOT_MOMENTS; ++n) {
-            soot_exp[n] = 3. - (3. * momV[n] + 2. * momS[n]);
-          }
-          amrex::ParallelFor(
-            ldata_p->state, [state_ma, soot_exp] AMREX_GPU_DEVICE(
-                              int box_no, int i, int j, int k) noexcept {
-              amrex::Array4<amrex::Real> soot(state_ma[box_no], FIRSTSOOT);
-              for (int n = 0; n < NUM_SOOT_MOMENTS; ++n) {
-                soot(i, j, k, n) *= std::pow(100., soot_exp[n]);
-              }
-              soot(i, j, k, NUMSOOTVAR - 1) *= 1.E6;
-            });
-          amrex::Gpu::streamSynchronize();
-        }
-      } else {
-        SootData* const sd = soot_model->getSootData();
-        amrex::Real moments[NUM_SOOT_MOMENTS + 1];
-        sd->initialSmallMomVals(moments);
+          source_plt_level, geom[a_lev], inSoot, FIRSTSOOT, NUMSOOTVAR, ldata_p->state);
+      if (pltfileSource == "C") {
+        SootConst sc;
+        amrex::Real* momV = sc.MomOrderV.data();
+        amrex::Real* momS = sc.MomOrderS.data();
         auto const& state_ma = ldata_p->state.arrays();
+        amrex::Real soot_exp[NUM_SOOT_MOMENTS] = {0.0};
+        for (int n = 0; n < NUM_SOOT_MOMENTS; ++n) {
+          soot_exp[n] = 3. - (3. * momV[n] + 2. * momS[n]);
+        }
         amrex::ParallelFor(
-          ldata_p->state, amrex::IntVect(0), NUM_SOOT_MOMENTS + 1,
-          [state_ma, moments] AMREX_GPU_DEVICE(
-            int box_no, int i, int j, int k, int n) noexcept {
+          ldata_p->state, [state_ma, soot_exp] AMREX_GPU_DEVICE(
+                            int box_no, int i, int j, int k) noexcept {
             amrex::Array4<amrex::Real> soot(state_ma[box_no], FIRSTSOOT);
-            soot(i, j, k, n) = moments[n];
+            for (int n = 0; n < NUM_SOOT_MOMENTS; ++n) {
+              soot(i, j, k, n) *= std::pow(100., soot_exp[n]);
+            }
+            soot(i, j, k, NUMSOOTVAR - 1) *= 1.E6;
           });
+        amrex::Gpu::streamSynchronize();
       }
+    } else {
+      SootData* const sd = soot_model->getSootData();
+      amrex::Real moments[NUM_SOOT_MOMENTS + 1];
+      sd->initialSmallMomVals(moments);
+      auto const& state_ma = ldata_p->state.arrays();
+      amrex::ParallelFor(
+        ldata_p->state, amrex::IntVect(0), NUM_SOOT_MOMENTS + 1,
+        [state_ma, moments] AMREX_GPU_DEVICE(
+          int box_no, int i, int j, int k, int n) noexcept {
+          amrex::Array4<amrex::Real> soot(state_ma[box_no], FIRSTSOOT);
+          soot(i, j, k, n) = moments[n];
+        });
     }
+  }
 #endif
   } // end if (!skip_plt_fill)
-
+  
   // Pressure and pressure gradients to zero
   ldata_p->press.setVal(0.0);
   ldata_p->gp.setVal(0.0);
@@ -1602,41 +1595,39 @@ PeleLM::computeLevelShift(
   // Compute coarsening ratio between plotfile level 0 and new level 0
   amrex::IntVect plt_domain_size = pltData.getGeom(0).Domain().size();
   amrex::IntVect new_domain_size = geom[0].Domain().size();
-
+  
   // Check if domains are identical (no coarsening)
   if (plt_domain_size == new_domain_size) {
     return 0;
   }
-
+  
   // Compute ratio in each direction
   amrex::IntVect ratio = plt_domain_size / new_domain_size;
-
+  
   // Validate ratio is isotropic
   for (int idim = 1; idim < AMREX_SPACEDIM; ++idim) {
     if (ratio[idim] != ratio[0]) {
       std::string ratio_str = "(";
       for (int d = 0; d < AMREX_SPACEDIM; ++d) {
         ratio_str += std::to_string(ratio[d]);
-        if (d < AMREX_SPACEDIM - 1)
-          ratio_str += ", ";
+        if (d < AMREX_SPACEDIM - 1) ratio_str += ", ";
       }
       ratio_str += ")";
       amrex::Abort(
         "peleLM.initDataPlt_coarsen: Coarsening ratio must be the same in all "
-        "directions. Found ratio: " +
-        ratio_str);
+        "directions. Found ratio: " + ratio_str);
     }
   }
-
+  
   int coarsen_factor = ratio[0];
-
+  
   // Check if new domain is actually coarser (ratio > 1)
   if (coarsen_factor < 1) {
     amrex::Abort(
       "peleLM.initDataPlt_coarsen: New level 0 domain is finer than plotfile "
       "level 0. This feature only supports coarsening, not refinement.");
   }
-
+  
   // Validate it's a power of 2 and within supported range (2, 4, 8)
   int level_shift = 0;
   if (coarsen_factor == 1) {
@@ -1649,14 +1640,12 @@ PeleLM::computeLevelShift(
     level_shift = 3;
   } else {
     amrex::Abort(
-      "peleLM.initDataPlt_coarsen: Coarsening ratio must be 2, 4, or 8. "
-      "Found: " +
+      "peleLM.initDataPlt_coarsen: Coarsening ratio must be 2, 4, or 8. Found: " +
       std::to_string(coarsen_factor));
   }
-
+  
   // Validate exact divisibility
-  amrex::IntVect remainder =
-    plt_domain_size - (new_domain_size * coarsen_factor);
+  amrex::IntVect remainder = plt_domain_size - (new_domain_size * coarsen_factor);
   if (remainder != amrex::IntVect::TheZeroVector()) {
     std::string plt_str = "(";
     std::string new_str = "(";
@@ -1672,19 +1661,18 @@ PeleLM::computeLevelShift(
     new_str += ")";
     amrex::Abort(
       "peleLM.initDataPlt_coarsen: Plotfile domain size must be exactly "
-      "divisible by new domain size. Plotfile: " +
-      plt_str + ", New: " + new_str +
+      "divisible by new domain size. Plotfile: " + plt_str +
+      ", New: " + new_str +
       ", Ratio: " + std::to_string(coarsen_factor));
   }
-
+  
   if (m_verbose > 0) {
-    amrex::Print() << "  peleLM.initDataPlt_coarsen: Detected "
-                   << coarsen_factor
+    amrex::Print() << "  peleLM.initDataPlt_coarsen: Detected " << coarsen_factor
                    << "x coarsening (level_shift=" << level_shift << ")\n";
     amrex::Print() << "  Plotfile level 0 domain: " << plt_domain_size << "\n";
     amrex::Print() << "  New level 0 domain: " << new_domain_size << "\n";
   }
-
+  
   return level_shift;
 }
 
@@ -1695,13 +1683,12 @@ PeleLM::coarsenLevelFromPlt(
   const amrex::IntVect& coarsen_ratio)
 {
   BL_PROFILE("PeleLMeX::coarsenLevelFromPlt()");
-
+  
   if (m_verbose > 0) {
-    amrex::Print() << "  Coarsening level " << a_lev
-                   << " from plotfile level 0 "
+    amrex::Print() << "  Coarsening level " << a_lev << " from plotfile level 0 "
                    << "with ratio " << coarsen_ratio << "\n";
   }
-
+  
 #ifdef AMREX_USE_EB
   if (!EBFactory(a_lev).isAllRegular()) {
     amrex::Abort(
@@ -1709,25 +1696,25 @@ PeleLM::coarsenLevelFromPlt(
       "This feature currently only works for non-EB cases.");
   }
 #endif
-
+  
   if (m_mesh_mapping) {
     amrex::Abort(
       "peleLM.initDataPlt_coarsen: Mesh mapping not supported. "
       "This feature currently only works without mesh mapping.");
   }
-
+  
   // Create temporary fine MultiFab matching plotfile level 0 resolution
   amrex::BoxArray fineBA = amrex::refine(grids[a_lev], coarsen_ratio);
   amrex::DistributionMapping fineDM(fineBA);
   amrex::MultiFab fineData(fineBA, fineDM, NVAR, 0);
-
+  
   // Fill fine data from plotfile level 0 using standard fillPatchFromPlt
   // This bypasses the coarsening restriction in PltFileManager
   amrex::Vector<std::string> spec_names;
   pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(
     spec_names, &(eos_parms.host_parm()));
   amrex::Vector<std::string> plt_vars = pltData.getVariableList();
-
+  
   // Find required variable indices in plotfile
   int idT = -1, idV = -1, idY = -1;
   for (int i = 0; i < plt_vars.size(); ++i) {
@@ -1744,21 +1731,20 @@ PeleLM::coarsenLevelFromPlt(
       idY = i;
     }
   }
-
+  
   if (idT < 0 || idV < 0 || idY < 0) {
-    amrex::Abort(
-      "coarsenLevelFromPlt: Could not find required variables in plotfile");
+    amrex::Abort("coarsenLevelFromPlt: Could not find required variables in plotfile");
   }
-
+  
   // Create fine geometry for interpolation
   amrex::Geometry fineGeom = amrex::refine(geom[a_lev], coarsen_ratio);
-
+  
   // Fill velocity
   pltData.fillPatchFromPlt(0, fineGeom, idV, VELX, AMREX_SPACEDIM, fineData);
-
-  // Fill temperature
+  
+  // Fill temperature  
   pltData.fillPatchFromPlt(0, fineGeom, idT, TEMP, 1, fineData);
-
+  
   // Fill species
   int nSpecPlt = 0;
   for (int i = 0; i < plt_vars.size(); ++i) {
@@ -1766,10 +1752,10 @@ PeleLM::coarsenLevelFromPlt(
       nSpecPlt++;
     }
   }
-
+  
   amrex::MultiFab fineSpecies(fineBA, fineDM, nSpecPlt, 0);
   pltData.fillPatchFromPlt(0, fineGeom, idY, 0, nSpecPlt, fineSpecies);
-
+  
   // Map species to current mechanism
   for (int i = 0; i < NUM_SPECIES; ++i) {
     std::string specName = "Y(" + spec_names[i] + ")";
@@ -1777,7 +1763,7 @@ PeleLM::coarsenLevelFromPlt(
     if (!m_initDataPlt_specname_map.empty()) {
       specString = m_initDataPlt_specname_map[i];
     }
-
+    
     int foundSpec = 0;
     for (int iplt = 0; iplt < nSpecPlt; ++iplt) {
       if (specString == plt_vars[idY + iplt]) {
@@ -1786,7 +1772,7 @@ PeleLM::coarsenLevelFromPlt(
         break;
       }
     }
-
+    
     if (foundSpec == 0) {
       // Try searching full variable list
       for (int iplt = 0; iplt < plt_vars.size(); ++iplt) {
@@ -1799,26 +1785,25 @@ PeleLM::coarsenLevelFromPlt(
         }
       }
     }
-
+    
     if (foundSpec == 0) {
       fineData.setVal(0.0, FIRSTSPEC + i, 1, 0);
       if (m_verbose > 0) {
-        amrex::Print() << "  Species " << specName
-                       << " not found, setting to 0\n";
+        amrex::Print() << "  Species " << specName << " not found, setting to 0\n";
       }
     }
   }
-
+  
   // Get level data pointer
   auto* ldata_p = getLevelDataPtr(a_lev, AmrNewTime);
-
+  
   // Apply conservative averaging to coarsen data
   // Average down all state components
-  amrex::average_down(fineData, ldata_p->state, 0, NVAR, coarsen_ratio);
-
+  amrex::average_down(
+    fineData, ldata_p->state, 0, NVAR, coarsen_ratio);
+  
   if (m_verbose > 1) {
-    amrex::Print() << "  Conservative coarsening complete for level " << a_lev
-                   << "\n";
+    amrex::Print() << "  Conservative coarsening complete for level " << a_lev << "\n";
   }
 }
 

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -1620,6 +1620,10 @@ PeleLM::coarsenLevelFromPlt(
   amrex::BoxArray fineBA = amrex::refine(grids[a_lev], coarsen_ratio);
   amrex::DistributionMapping fineDM(fineBA);
   amrex::MultiFab fineData(fineBA, fineDM, NVAR, 0);
+  
+  // Initialize all components to avoid propagating garbage in uninitialized fields
+  // (e.g., RHORT, plasma/soot fields) when averaging down
+  fineData.setVal(0.0);
 
   // Fill fine data from plotfile level 0 using standard fillPatchFromPlt
   // This bypasses the coarsening restriction in PltFileManager

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -1246,15 +1246,15 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
   // Track whether we coarsened the base level (for skip_plt_fill logic later)
   bool did_coarsen_base = false;
   
-  // Handle multi-level coarsening with peleLM.intDataPlt_coarsen
-  if (m_intDataPlt_coarsen) {
+  // Handle multi-level coarsening with peleLM.initDataPlt_coarsen
+  if (m_initDataPlt_coarsen) {
     // Compute level shift once at level 0
     if (a_lev == 0) {
       m_level_shift = computeLevelShift(pltData);
       
       if (m_level_shift > 0) {
         amrex::Print() 
-          << "  peleLM.intDataPlt_coarsen: Level mapping active (shift=" 
+          << "  peleLM.initDataPlt_coarsen: Level mapping active (shift=" 
           << m_level_shift << ")\n";
         amrex::Print() 
           << "  Plotfile level K will become new level K+" 
@@ -1267,7 +1267,7 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
         
         if (min_required_plt_lev > max_plt_lev) {
           amrex::Abort(
-            "peleLM.intDataPlt_coarsen: Insufficient plotfile levels. "
+            "peleLM.initDataPlt_coarsen: Insufficient plotfile levels. "
             "Need plotfile level " + std::to_string(min_required_plt_lev) +
             " but plotfile only has " + std::to_string(max_plt_lev) + " levels.");
         }
@@ -1391,7 +1391,7 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
   bool skip_plt_fill = false;
   int source_plt_level = a_lev; // Default: no level shift
   
-  if (m_intDataPlt_coarsen && m_level_shift > 0) {
+  if (m_initDataPlt_coarsen && m_level_shift > 0) {
     // Coarser level 0 was already handled - data was filled by coarsenLevelFromPlt
     if (did_coarsen_base) {
       skip_plt_fill = true;
@@ -1614,7 +1614,7 @@ PeleLM::computeLevelShift(
       }
       ratio_str += ")";
       amrex::Abort(
-        "peleLM.intDataPlt_coarsen: Coarsening ratio must be the same in all "
+        "peleLM.initDataPlt_coarsen: Coarsening ratio must be the same in all "
         "directions. Found ratio: " + ratio_str);
     }
   }
@@ -1624,7 +1624,7 @@ PeleLM::computeLevelShift(
   // Check if new domain is actually coarser (ratio > 1)
   if (coarsen_factor < 1) {
     amrex::Abort(
-      "peleLM.intDataPlt_coarsen: New level 0 domain is finer than plotfile "
+      "peleLM.initDataPlt_coarsen: New level 0 domain is finer than plotfile "
       "level 0. This feature only supports coarsening, not refinement.");
   }
   
@@ -1640,7 +1640,7 @@ PeleLM::computeLevelShift(
     level_shift = 3;
   } else {
     amrex::Abort(
-      "peleLM.intDataPlt_coarsen: Coarsening ratio must be 2, 4, or 8. Found: " +
+      "peleLM.initDataPlt_coarsen: Coarsening ratio must be 2, 4, or 8. Found: " +
       std::to_string(coarsen_factor));
   }
   
@@ -1660,14 +1660,14 @@ PeleLM::computeLevelShift(
     plt_str += ")";
     new_str += ")";
     amrex::Abort(
-      "peleLM.intDataPlt_coarsen: Plotfile domain size must be exactly "
+      "peleLM.initDataPlt_coarsen: Plotfile domain size must be exactly "
       "divisible by new domain size. Plotfile: " + plt_str +
       ", New: " + new_str +
       ", Ratio: " + std::to_string(coarsen_factor));
   }
   
   if (m_verbose > 0) {
-    amrex::Print() << "  peleLM.intDataPlt_coarsen: Detected " << coarsen_factor
+    amrex::Print() << "  peleLM.initDataPlt_coarsen: Detected " << coarsen_factor
                    << "x coarsening (level_shift=" << level_shift << ")\n";
     amrex::Print() << "  Plotfile level 0 domain: " << plt_domain_size << "\n";
     amrex::Print() << "  New level 0 domain: " << new_domain_size << "\n";
@@ -1692,14 +1692,14 @@ PeleLM::coarsenLevelFromPlt(
 #ifdef AMREX_USE_EB
   if (!EBFactory(a_lev).isAllRegular()) {
     amrex::Abort(
-      "peleLM.intDataPlt_coarsen: EB geometry not supported. "
+      "peleLM.initDataPlt_coarsen: EB geometry not supported. "
       "This feature currently only works for non-EB cases.");
   }
 #endif
   
   if (m_mesh_mapping) {
     amrex::Abort(
-      "peleLM.intDataPlt_coarsen: Mesh mapping not supported. "
+      "peleLM.initDataPlt_coarsen: Mesh mapping not supported. "
       "This feature currently only works without mesh mapping.");
   }
   

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -1242,6 +1242,76 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
   }
   auto& pltData = *pltDataPtr;
   amrex::Vector<std::string> plt_vars = pltData.getVariableList();
+  
+  // Track whether we coarsened the base level (for skip_plt_fill logic later)
+  bool did_coarsen_base = false;
+  
+  // Handle multi-level coarsening with peleLM.intDataPlt_coarsen
+  if (m_intDataPlt_coarsen) {
+    // Compute level shift once at level 0
+    if (a_lev == 0) {
+      m_level_shift = computeLevelShift(pltData);
+      
+      if (m_level_shift > 0) {
+        amrex::Print() 
+          << "  peleLM.intDataPlt_coarsen: Level mapping active (shift=" 
+          << m_level_shift << ")\n";
+        amrex::Print() 
+          << "  Plotfile level K will become new level K+" 
+          << m_level_shift << "\n";
+        
+        // Verify we have enough plotfile levels
+        int max_plt_lev = pltData.getNlev() - 1;
+        int max_new_lev = finest_level;
+        int min_required_plt_lev = max_new_lev - m_level_shift;
+        
+        if (min_required_plt_lev > max_plt_lev) {
+          amrex::Abort(
+            "peleLM.intDataPlt_coarsen: Insufficient plotfile levels. "
+            "Need plotfile level " + std::to_string(min_required_plt_lev) +
+            " but plotfile only has " + std::to_string(max_plt_lev) + " levels.");
+        }
+      }
+    }
+    
+    // Determine source plotfile level for current AMR level
+    int source_plt_level = a_lev - m_level_shift;
+    
+    // Coarsen from plotfile level 0 to new coarser level 0
+    // Must check this first, since a_lev==0 gives source_plt_level < 0
+    if (a_lev == 0 && m_level_shift > 0) {
+      amrex::IntVect coarsen_ratio = 
+        amrex::IntVect(AMREX_D_DECL(1 << m_level_shift, 
+                                     1 << m_level_shift, 
+                                     1 << m_level_shift));
+      
+      // coarsenLevelFromPlt fills ldata_p->state directly
+      coarsenLevelFromPlt(a_lev, pltData, coarsen_ratio);
+      did_coarsen_base = true;
+    }
+    // Intermediate levels (a_lev < m_level_shift, but not level 0)
+    // These levels don't have corresponding plotfile data, so interpolate
+    // from coarser level
+    else if (source_plt_level < 0) {
+      if (m_verbose > 0) {
+        amrex::Print() 
+          << "  Level " << a_lev << " (intermediate): Interpolating from level " 
+          << (a_lev - 1) << "\n";
+        amrex::Print() 
+          << "  (Will be refined by regridding based on tagging criteria)\n";
+      }
+      
+      // Get level data
+      auto* ldata_p = getLevelDataPtr(a_lev, AmrNewTime);
+      
+      // Interpolate all state components from level a_lev-1
+      // Use fillcoarsepatch which does conservative interpolation
+      fillcoarsepatch_state(a_lev, m_cur_time, ldata_p->state, 0);
+
+      return;
+    }
+  }
+  
   if (m_do_reset_time == 0) {
     m_cur_time = pltData.getTime();
     m_nstep = pltData.getNsteps();
@@ -1317,18 +1387,41 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
   // Get level data
   auto* ldata_p = getLevelDataPtr(a_lev, AmrNewTime);
 
-  // Velocity
-  pltData.fillPatchFromPlt(
-    a_lev, geom[a_lev], idV, VELX, AMREX_SPACEDIM, ldata_p->state);
+  // Determine if we need to fill from plotfile or if already filled by coarsening
+  bool skip_plt_fill = false;
+  int source_plt_level = a_lev; // Default: no level shift
+  
+  if (m_intDataPlt_coarsen && m_level_shift > 0) {
+    // Coarser level 0 was already handled - data was filled by coarsenLevelFromPlt
+    if (did_coarsen_base) {
+      skip_plt_fill = true;
+      if (m_verbose > 0) {
+        amrex::Print() << "  Skipping fillPatchFromPlt (already coarsened)\n";
+      }
+    } else {
+      source_plt_level = a_lev - m_level_shift;
+      // Direct mapping with level shift
+      if (source_plt_level >= 0 && m_verbose > 0) {
+        amrex::Print() 
+          << "  Level " << a_lev << ": Reading from plotfile level " 
+          << source_plt_level << "\n";
+      }
+    }
+  }
 
-  // Temperature
-  pltData.fillPatchFromPlt(a_lev, geom[a_lev], idT, TEMP, 1, ldata_p->state);
+  if (!skip_plt_fill) {
+    // Velocity
+    pltData.fillPatchFromPlt(
+      source_plt_level, geom[a_lev], idV, VELX, AMREX_SPACEDIM, ldata_p->state);
 
-  // Species
-  // Hold the species in temporary MF before copying to level data
-  // in case the number of species differs.
-  amrex::MultiFab speciesPlt(grids[a_lev], dmap[a_lev], nSpecPlt, 0);
-  pltData.fillPatchFromPlt(a_lev, geom[a_lev], idY, 0, nSpecPlt, speciesPlt);
+    // Temperature
+    pltData.fillPatchFromPlt(source_plt_level, geom[a_lev], idT, TEMP, 1, ldata_p->state);
+
+    // Species
+    // Hold the species in temporary MF before copying to level data
+    // in case the number of species differs.
+    amrex::MultiFab speciesPlt(grids[a_lev], dmap[a_lev], nSpecPlt, 0);
+    pltData.fillPatchFromPlt(source_plt_level, geom[a_lev], idY, 0, nSpecPlt, speciesPlt);
   for (int i = 0; i < NUM_SPECIES; ++i) {
     std::string specName = "Y(" + spec_names[i] + ")";
     std::string specString = specName;
@@ -1356,7 +1449,7 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
                            << " from plotfile entry " << specString << "\n";
           }
           pltData.fillPatchFromPlt(
-            a_lev, geom[a_lev], iplt, FIRSTSPEC + i, 1, ldata_p->state);
+            source_plt_level, geom[a_lev], iplt, FIRSTSPEC + i, 1, ldata_p->state);
         }
       }
     }
@@ -1384,16 +1477,16 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
   }
 
 #ifdef PELE_USE_PLASMA
-  // nE
-  pltData.fillPatchFromPlt(a_lev, geom[a_lev], inE, NE, 1, ldata_p->state);
-  // phiV
-  pltData.fillPatchFromPlt(a_lev, geom[a_lev], iPhiV, PHIV, 1, ldata_p->state);
+    // nE
+    pltData.fillPatchFromPlt(source_plt_level, geom[a_lev], inE, NE, 1, ldata_p->state);
+    // phiV
+    pltData.fillPatchFromPlt(source_plt_level, geom[a_lev], iPhiV, PHIV, 1, ldata_p->state);
 #endif
 #ifdef PELE_USE_SOOT
-  if (do_soot_solve) {
-    if (inSoot >= 0) {
-      pltData.fillPatchFromPlt(
-        a_lev, geom[a_lev], inSoot, FIRSTSOOT, NUMSOOTVAR, ldata_p->state);
+    if (do_soot_solve) {
+      if (inSoot >= 0) {
+        pltData.fillPatchFromPlt(
+          source_plt_level, geom[a_lev], inSoot, FIRSTSOOT, NUMSOOTVAR, ldata_p->state);
       if (pltfileSource == "C") {
         SootConst sc;
         amrex::Real* momV = sc.MomOrderV.data();
@@ -1429,6 +1522,8 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
     }
   }
 #endif
+  } // end if (!skip_plt_fill)
+  
   // Pressure and pressure gradients to zero
   ldata_p->press.setVal(0.0);
   ldata_p->gp.setVal(0.0);
@@ -1490,6 +1585,225 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
   setThermoPress(a_lev, AmrNewTime);
   if (m_has_divu != 0) {
     ldata_p->divu.setVal(0.0);
+  }
+}
+
+int
+PeleLM::computeLevelShift(
+  pele::physics::pltfilemanager::PltFileManager& pltData)
+{
+  // Compute coarsening ratio between plotfile level 0 and new level 0
+  amrex::IntVect plt_domain_size = pltData.getGeom(0).Domain().size();
+  amrex::IntVect new_domain_size = geom[0].Domain().size();
+  
+  // Check if domains are identical (no coarsening)
+  if (plt_domain_size == new_domain_size) {
+    return 0;
+  }
+  
+  // Compute ratio in each direction
+  amrex::IntVect ratio = plt_domain_size / new_domain_size;
+  
+  // Validate ratio is isotropic
+  for (int idim = 1; idim < AMREX_SPACEDIM; ++idim) {
+    if (ratio[idim] != ratio[0]) {
+      std::string ratio_str = "(";
+      for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+        ratio_str += std::to_string(ratio[d]);
+        if (d < AMREX_SPACEDIM - 1) ratio_str += ", ";
+      }
+      ratio_str += ")";
+      amrex::Abort(
+        "peleLM.intDataPlt_coarsen: Coarsening ratio must be the same in all "
+        "directions. Found ratio: " + ratio_str);
+    }
+  }
+  
+  int coarsen_factor = ratio[0];
+  
+  // Check if new domain is actually coarser (ratio > 1)
+  if (coarsen_factor < 1) {
+    amrex::Abort(
+      "peleLM.intDataPlt_coarsen: New level 0 domain is finer than plotfile "
+      "level 0. This feature only supports coarsening, not refinement.");
+  }
+  
+  // Validate it's a power of 2 and within supported range (2, 4, 8)
+  int level_shift = 0;
+  if (coarsen_factor == 1) {
+    level_shift = 0;
+  } else if (coarsen_factor == 2) {
+    level_shift = 1;
+  } else if (coarsen_factor == 4) {
+    level_shift = 2;
+  } else if (coarsen_factor == 8) {
+    level_shift = 3;
+  } else {
+    amrex::Abort(
+      "peleLM.intDataPlt_coarsen: Coarsening ratio must be 2, 4, or 8. Found: " +
+      std::to_string(coarsen_factor));
+  }
+  
+  // Validate exact divisibility
+  amrex::IntVect remainder = plt_domain_size - (new_domain_size * coarsen_factor);
+  if (remainder != amrex::IntVect::TheZeroVector()) {
+    std::string plt_str = "(";
+    std::string new_str = "(";
+    for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+      plt_str += std::to_string(plt_domain_size[d]);
+      new_str += std::to_string(new_domain_size[d]);
+      if (d < AMREX_SPACEDIM - 1) {
+        plt_str += ", ";
+        new_str += ", ";
+      }
+    }
+    plt_str += ")";
+    new_str += ")";
+    amrex::Abort(
+      "peleLM.intDataPlt_coarsen: Plotfile domain size must be exactly "
+      "divisible by new domain size. Plotfile: " + plt_str +
+      ", New: " + new_str +
+      ", Ratio: " + std::to_string(coarsen_factor));
+  }
+  
+  if (m_verbose > 0) {
+    amrex::Print() << "  peleLM.intDataPlt_coarsen: Detected " << coarsen_factor
+                   << "x coarsening (level_shift=" << level_shift << ")\n";
+    amrex::Print() << "  Plotfile level 0 domain: " << plt_domain_size << "\n";
+    amrex::Print() << "  New level 0 domain: " << new_domain_size << "\n";
+  }
+  
+  return level_shift;
+}
+
+void
+PeleLM::coarsenLevelFromPlt(
+  const int a_lev,
+  pele::physics::pltfilemanager::PltFileManager& pltData,
+  const amrex::IntVect& coarsen_ratio)
+{
+  BL_PROFILE("PeleLMeX::coarsenLevelFromPlt()");
+  
+  if (m_verbose > 0) {
+    amrex::Print() << "  Coarsening level " << a_lev << " from plotfile level 0 "
+                   << "with ratio " << coarsen_ratio << "\n";
+  }
+  
+#ifdef AMREX_USE_EB
+  if (!EBFactory(a_lev).isAllRegular()) {
+    amrex::Abort(
+      "peleLM.intDataPlt_coarsen: EB geometry not supported. "
+      "This feature currently only works for non-EB cases.");
+  }
+#endif
+  
+  if (m_mesh_mapping) {
+    amrex::Abort(
+      "peleLM.intDataPlt_coarsen: Mesh mapping not supported. "
+      "This feature currently only works without mesh mapping.");
+  }
+  
+  // Create temporary fine MultiFab matching plotfile level 0 resolution
+  amrex::BoxArray fineBA = amrex::refine(grids[a_lev], coarsen_ratio);
+  amrex::DistributionMapping fineDM(fineBA);
+  amrex::MultiFab fineData(fineBA, fineDM, NVAR, 0);
+  
+  // Fill fine data from plotfile level 0 using standard fillPatchFromPlt
+  // This bypasses the coarsening restriction in PltFileManager
+  amrex::Vector<std::string> spec_names;
+  pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(
+    spec_names, &(eos_parms.host_parm()));
+  amrex::Vector<std::string> plt_vars = pltData.getVariableList();
+  
+  // Find required variable indices in plotfile
+  int idT = -1, idV = -1, idY = -1;
+  for (int i = 0; i < plt_vars.size(); ++i) {
+    if (pltfileSource == "LM" && plt_vars[i] == "temp") {
+      idT = i;
+    } else if (pltfileSource == "C" && plt_vars[i] == "Temp") {
+      idT = i;
+    }
+    if (plt_vars[i] == "x_velocity") {
+      idV = i;
+    }
+    std::string firstChars = plt_vars[i].substr(0, 2);
+    if (firstChars == "Y(" && idY < 0) {
+      idY = i;
+    }
+  }
+  
+  if (idT < 0 || idV < 0 || idY < 0) {
+    amrex::Abort("coarsenLevelFromPlt: Could not find required variables in plotfile");
+  }
+  
+  // Create fine geometry for interpolation
+  amrex::Geometry fineGeom = amrex::refine(geom[a_lev], coarsen_ratio);
+  
+  // Fill velocity
+  pltData.fillPatchFromPlt(0, fineGeom, idV, VELX, AMREX_SPACEDIM, fineData);
+  
+  // Fill temperature  
+  pltData.fillPatchFromPlt(0, fineGeom, idT, TEMP, 1, fineData);
+  
+  // Fill species
+  int nSpecPlt = 0;
+  for (int i = 0; i < plt_vars.size(); ++i) {
+    if (plt_vars[i].substr(0, 2) == "Y(") {
+      nSpecPlt++;
+    }
+  }
+  
+  amrex::MultiFab fineSpecies(fineBA, fineDM, nSpecPlt, 0);
+  pltData.fillPatchFromPlt(0, fineGeom, idY, 0, nSpecPlt, fineSpecies);
+  
+  // Map species to current mechanism
+  for (int i = 0; i < NUM_SPECIES; ++i) {
+    std::string specName = "Y(" + spec_names[i] + ")";
+    std::string specString = specName;
+    if (!m_initDataPlt_specname_map.empty()) {
+      specString = m_initDataPlt_specname_map[i];
+    }
+    
+    int foundSpec = 0;
+    for (int iplt = 0; iplt < nSpecPlt; ++iplt) {
+      if (specString == plt_vars[idY + iplt]) {
+        amrex::MultiFab::Copy(fineData, fineSpecies, iplt, FIRSTSPEC + i, 1, 0);
+        foundSpec = 1;
+        break;
+      }
+    }
+    
+    if (foundSpec == 0) {
+      // Try searching full variable list
+      for (int iplt = 0; iplt < plt_vars.size(); ++iplt) {
+        if (specString == plt_vars[iplt]) {
+          amrex::MultiFab tmpSpec(fineBA, fineDM, 1, 0);
+          pltData.fillPatchFromPlt(0, fineGeom, iplt, 0, 1, tmpSpec);
+          amrex::MultiFab::Copy(fineData, tmpSpec, 0, FIRSTSPEC + i, 1, 0);
+          foundSpec = 1;
+          break;
+        }
+      }
+    }
+    
+    if (foundSpec == 0) {
+      fineData.setVal(0.0, FIRSTSPEC + i, 1, 0);
+      if (m_verbose > 0) {
+        amrex::Print() << "  Species " << specName << " not found, setting to 0\n";
+      }
+    }
+  }
+  
+  // Get level data pointer
+  auto* ldata_p = getLevelDataPtr(a_lev, AmrNewTime);
+  
+  // Apply conservative averaging to coarsen data
+  // Average down all state components
+  amrex::average_down(
+    fineData, ldata_p->state, 0, NVAR, coarsen_ratio);
+  
+  if (m_verbose > 1) {
+    amrex::Print() << "  Conservative coarsening complete for level " << a_lev << "\n";
   }
 }
 

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -1636,9 +1636,9 @@ PeleLM::coarsenLevelFromPlt(
   // Find required variable indices in plotfile
   int idT = -1, idV = -1, idY = -1;
   for (int i = 0; i < plt_vars.size(); ++i) {
-    if (pltfileSource == "LM" && plt_vars[i] == "temp") {
-      idT = i;
-    } else if (pltfileSource == "C" && plt_vars[i] == "Temp") {
+    if (
+      (pltfileSource == "LM" && plt_vars[i] == "temp") ||
+      (pltfileSource == "C" && plt_vars[i] == "Temp")) {
       idT = i;
     }
     if (plt_vars[i] == "x_velocity") {
@@ -1666,8 +1666,8 @@ PeleLM::coarsenLevelFromPlt(
 
   // Fill species
   int nSpecPlt = 0;
-  for (int i = 0; i < plt_vars.size(); ++i) {
-    if (plt_vars[i].substr(0, 2) == "Y(") {
+  for (const auto& var : plt_vars) {
+    if (var.substr(0, 2) == "Y(") {
       nSpecPlt++;
     }
   }

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -1365,7 +1365,8 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
     if (did_coarsen_base) {
       skip_plt_fill = true;
     } else {
-      source_plt_level = a_lev - m_level_shift; // Read from corresponding plotfile level
+      source_plt_level =
+        a_lev - m_level_shift; // Read from corresponding plotfile level
       if (m_verbose > 0) {
         amrex::Print() << "  Level " << a_lev
                        << ": Reading from plotfile level " << source_plt_level
@@ -1620,9 +1621,9 @@ PeleLM::coarsenLevelFromPlt(
   amrex::BoxArray fineBA = amrex::refine(grids[a_lev], coarsen_ratio);
   amrex::DistributionMapping fineDM(fineBA);
   amrex::MultiFab fineData(fineBA, fineDM, NVAR, 0);
-  
-  // Initialize all components to avoid propagating garbage in uninitialized fields
-  // (e.g., RHORT, plasma/soot fields) when averaging down
+
+  // Initialize all components to avoid propagating garbage in uninitialized
+  // fields (e.g., RHORT, plasma/soot fields) when averaging down
   fineData.setVal(0.0);
 
   // Fill fine data from plotfile level 0 using standard fillPatchFromPlt

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -1246,66 +1246,38 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
   // Track whether we coarsened the base level (for skip_plt_fill logic later)
   bool did_coarsen_base = false;
 
-  // Handle multi-level coarsening with peleLM.initDataPlt_coarsen
+  // Handle 2x coarsening with peleLM.initDataPlt_coarsen
   if (m_initDataPlt_coarsen) {
-    // Compute level shift once at level 0
     if (a_lev == 0) {
       m_level_shift = computeLevelShift(pltData);
 
       if (m_level_shift > 0) {
+        amrex::Print() << "  peleLM.initDataPlt_coarsen: Coarsening active\n";
         amrex::Print()
-          << "  peleLM.initDataPlt_coarsen: Level mapping active (shift="
-          << m_level_shift << ")\n";
-        amrex::Print() << "  Plotfile level K will become new level K+"
-                       << m_level_shift << "\n";
+          << "  Plotfile level K will become new level K+1\n";
 
         // Verify we have enough plotfile levels
-        int max_plt_lev = pltData.getNlev() - 1;
-        int max_new_lev = finest_level;
-        int min_required_plt_lev = max_new_lev - m_level_shift;
-
-        if (min_required_plt_lev > max_plt_lev) {
+        if (finest_level - 1 > pltData.getNlev() - 1) {
           amrex::Abort(
-            "peleLM.initDataPlt_coarsen: Insufficient plotfile levels. "
-            "Need plotfile level " +
-            std::to_string(min_required_plt_lev) + " but plotfile only has " +
-            std::to_string(max_plt_lev) + " levels.");
+            "peleLM.initDataPlt_coarsen: Insufficient plotfile levels.");
         }
       }
     }
 
-    // Determine source plotfile level for current AMR level
-    int source_plt_level = a_lev - m_level_shift;
-
     // Coarsen from plotfile level 0 to new coarser level 0
-    // Must check this first, since a_lev==0 gives source_plt_level < 0
     if (a_lev == 0 && m_level_shift > 0) {
-      amrex::IntVect coarsen_ratio = amrex::IntVect(AMREX_D_DECL(
-        1 << m_level_shift, 1 << m_level_shift, 1 << m_level_shift));
-
-      // coarsenLevelFromPlt fills ldata_p->state directly
-      coarsenLevelFromPlt(a_lev, pltData, coarsen_ratio);
+      coarsenLevelFromPlt(a_lev, pltData, amrex::IntVect(AMREX_D_DECL(2, 2, 2)));
       did_coarsen_base = true;
     }
-    // Intermediate levels (a_lev < m_level_shift, but not level 0)
-    // These levels don't have corresponding plotfile data, so interpolate
-    // from coarser level
-    else if (source_plt_level < 0) {
+    // Intermediate levels don't have corresponding plotfile data - interpolate
+    else if (a_lev > 0 && a_lev < m_level_shift) {
       if (m_verbose > 0) {
         amrex::Print() << "  Level " << a_lev
-                       << " (intermediate): Interpolating from level "
-                       << (a_lev - 1) << "\n";
-        amrex::Print()
-          << "  (Will be refined by regridding based on tagging criteria)\n";
+                       << ": Interpolating from level " << (a_lev - 1) << "\n";
       }
 
-      // Get level data
       auto* ldata_p = getLevelDataPtr(a_lev, AmrNewTime);
-
-      // Interpolate all state components from level a_lev-1
-      // Use fillcoarsepatch which does conservative interpolation
       fillcoarsepatch_state(a_lev, m_cur_time, ldata_p->state, 0);
-
       return;
     }
   }
@@ -1385,26 +1357,18 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
   // Get level data
   auto* ldata_p = getLevelDataPtr(a_lev, AmrNewTime);
 
-  // Determine if we need to fill from plotfile or if already filled by
-  // coarsening
+  // Determine if we need to fill from plotfile
   bool skip_plt_fill = false;
-  int source_plt_level = a_lev; // Default: no level shift
+  int source_plt_level = a_lev;
 
   if (m_initDataPlt_coarsen && m_level_shift > 0) {
-    // Coarser level 0 was already handled - data was filled by
-    // coarsenLevelFromPlt
     if (did_coarsen_base) {
       skip_plt_fill = true;
-      if (m_verbose > 0) {
-        amrex::Print() << "  Skipping fillPatchFromPlt (already coarsened)\n";
-      }
     } else {
-      source_plt_level = a_lev - m_level_shift;
-      // Direct mapping with level shift
-      if (source_plt_level >= 0 && m_verbose > 0) {
-        amrex::Print() << "  Level " << a_lev
-                       << ": Reading from plotfile level " << source_plt_level
-                       << "\n";
+      source_plt_level = a_lev - 1; // Read from previous plotfile level
+      if (m_verbose > 0) {
+        amrex::Print() << "  Level " << a_lev << ": Reading from plotfile level "
+                       << source_plt_level << "\n";
       }
     }
   }
@@ -1599,93 +1563,28 @@ int
 PeleLM::computeLevelShift(
   pele::physics::pltfilemanager::PltFileManager& pltData)
 {
-  // Compute coarsening ratio between plotfile level 0 and new level 0
   amrex::IntVect plt_domain_size = pltData.getGeom(0).Domain().size();
   amrex::IntVect new_domain_size = geom[0].Domain().size();
 
-  // Check if domains are identical (no coarsening)
+  // No coarsening if domains match
   if (plt_domain_size == new_domain_size) {
     return 0;
   }
 
-  // Compute ratio in each direction
-  amrex::IntVect ratio = plt_domain_size / new_domain_size;
-
-  // Validate ratio is isotropic
-  for (int idim = 1; idim < AMREX_SPACEDIM; ++idim) {
-    if (ratio[idim] != ratio[0]) {
-      std::string ratio_str = "(";
-      for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-        ratio_str += std::to_string(ratio[d]);
-        if (d < AMREX_SPACEDIM - 1)
-          ratio_str += ", ";
-      }
-      ratio_str += ")";
-      amrex::Abort(
-        "peleLM.initDataPlt_coarsen: Coarsening ratio must be the same in all "
-        "directions. Found ratio: " +
-        ratio_str);
-    }
-  }
-
-  int coarsen_factor = ratio[0];
-
-  // Check if new domain is actually coarser (ratio > 1)
-  if (coarsen_factor < 1) {
+  // Validate 2x coarsening in all directions
+  if (plt_domain_size != new_domain_size * 2) {
     amrex::Abort(
-      "peleLM.initDataPlt_coarsen: New level 0 domain is finer than plotfile "
-      "level 0. This feature only supports coarsening, not refinement.");
-  }
-
-  // Validate it's a power of 2 and within supported range (2, 4, 8)
-  int level_shift = 0;
-  if (coarsen_factor == 1) {
-    level_shift = 0;
-  } else if (coarsen_factor == 2) {
-    level_shift = 1;
-  } else if (coarsen_factor == 4) {
-    level_shift = 2;
-  } else if (coarsen_factor == 8) {
-    level_shift = 3;
-  } else {
-    amrex::Abort(
-      "peleLM.initDataPlt_coarsen: Coarsening ratio must be 2, 4, or 8. "
-      "Found: " +
-      std::to_string(coarsen_factor));
-  }
-
-  // Validate exact divisibility
-  amrex::IntVect remainder =
-    plt_domain_size - (new_domain_size * coarsen_factor);
-  if (remainder != amrex::IntVect::TheZeroVector()) {
-    std::string plt_str = "(";
-    std::string new_str = "(";
-    for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-      plt_str += std::to_string(plt_domain_size[d]);
-      new_str += std::to_string(new_domain_size[d]);
-      if (d < AMREX_SPACEDIM - 1) {
-        plt_str += ", ";
-        new_str += ", ";
-      }
-    }
-    plt_str += ")";
-    new_str += ")";
-    amrex::Abort(
-      "peleLM.initDataPlt_coarsen: Plotfile domain size must be exactly "
-      "divisible by new domain size. Plotfile: " +
-      plt_str + ", New: " + new_str +
-      ", Ratio: " + std::to_string(coarsen_factor));
+      "peleLM.initDataPlt_coarsen: Only 2x coarsening is supported. "
+      "Plotfile domain must be exactly 2x larger in each direction.");
   }
 
   if (m_verbose > 0) {
-    amrex::Print() << "  peleLM.initDataPlt_coarsen: Detected "
-                   << coarsen_factor
-                   << "x coarsening (level_shift=" << level_shift << ")\n";
-    amrex::Print() << "  Plotfile level 0 domain: " << plt_domain_size << "\n";
-    amrex::Print() << "  New level 0 domain: " << new_domain_size << "\n";
+    amrex::Print() << "  peleLM.initDataPlt_coarsen: 2x coarsening detected\n";
+    amrex::Print() << "  Plotfile level 0: " << plt_domain_size << "\n";
+    amrex::Print() << "  New level 0: " << new_domain_size << "\n";
   }
 
-  return level_shift;
+  return 1; // level_shift = 1 for 2x coarsening
 }
 
 void

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -1365,7 +1365,7 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
     if (did_coarsen_base) {
       skip_plt_fill = true;
     } else {
-      source_plt_level = a_lev - 1; // Read from previous plotfile level
+      source_plt_level = a_lev - m_level_shift; // Read from corresponding plotfile level
       if (m_verbose > 0) {
         amrex::Print() << "  Level " << a_lev
                        << ": Reading from plotfile level " << source_plt_level

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -1242,49 +1242,47 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
   }
   auto& pltData = *pltDataPtr;
   amrex::Vector<std::string> plt_vars = pltData.getVariableList();
-  
+
   // Track whether we coarsened the base level (for skip_plt_fill logic later)
   bool did_coarsen_base = false;
-  
+
   // Handle multi-level coarsening with peleLM.initDataPlt_coarsen
   if (m_initDataPlt_coarsen) {
     // Compute level shift once at level 0
     if (a_lev == 0) {
       m_level_shift = computeLevelShift(pltData);
-      
+
       if (m_level_shift > 0) {
-        amrex::Print() 
-          << "  peleLM.initDataPlt_coarsen: Level mapping active (shift=" 
+        amrex::Print()
+          << "  peleLM.initDataPlt_coarsen: Level mapping active (shift="
           << m_level_shift << ")\n";
-        amrex::Print() 
-          << "  Plotfile level K will become new level K+" 
-          << m_level_shift << "\n";
-        
+        amrex::Print() << "  Plotfile level K will become new level K+"
+                       << m_level_shift << "\n";
+
         // Verify we have enough plotfile levels
         int max_plt_lev = pltData.getNlev() - 1;
         int max_new_lev = finest_level;
         int min_required_plt_lev = max_new_lev - m_level_shift;
-        
+
         if (min_required_plt_lev > max_plt_lev) {
           amrex::Abort(
             "peleLM.initDataPlt_coarsen: Insufficient plotfile levels. "
-            "Need plotfile level " + std::to_string(min_required_plt_lev) +
-            " but plotfile only has " + std::to_string(max_plt_lev) + " levels.");
+            "Need plotfile level " +
+            std::to_string(min_required_plt_lev) + " but plotfile only has " +
+            std::to_string(max_plt_lev) + " levels.");
         }
       }
     }
-    
+
     // Determine source plotfile level for current AMR level
     int source_plt_level = a_lev - m_level_shift;
-    
+
     // Coarsen from plotfile level 0 to new coarser level 0
     // Must check this first, since a_lev==0 gives source_plt_level < 0
     if (a_lev == 0 && m_level_shift > 0) {
-      amrex::IntVect coarsen_ratio = 
-        amrex::IntVect(AMREX_D_DECL(1 << m_level_shift, 
-                                     1 << m_level_shift, 
-                                     1 << m_level_shift));
-      
+      amrex::IntVect coarsen_ratio = amrex::IntVect(AMREX_D_DECL(
+        1 << m_level_shift, 1 << m_level_shift, 1 << m_level_shift));
+
       // coarsenLevelFromPlt fills ldata_p->state directly
       coarsenLevelFromPlt(a_lev, pltData, coarsen_ratio);
       did_coarsen_base = true;
@@ -1294,16 +1292,16 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
     // from coarser level
     else if (source_plt_level < 0) {
       if (m_verbose > 0) {
-        amrex::Print() 
-          << "  Level " << a_lev << " (intermediate): Interpolating from level " 
-          << (a_lev - 1) << "\n";
-        amrex::Print() 
+        amrex::Print() << "  Level " << a_lev
+                       << " (intermediate): Interpolating from level "
+                       << (a_lev - 1) << "\n";
+        amrex::Print()
           << "  (Will be refined by regridding based on tagging criteria)\n";
       }
-      
+
       // Get level data
       auto* ldata_p = getLevelDataPtr(a_lev, AmrNewTime);
-      
+
       // Interpolate all state components from level a_lev-1
       // Use fillcoarsepatch which does conservative interpolation
       fillcoarsepatch_state(a_lev, m_cur_time, ldata_p->state, 0);
@@ -1311,7 +1309,7 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
       return;
     }
   }
-  
+
   if (m_do_reset_time == 0) {
     m_cur_time = pltData.getTime();
     m_nstep = pltData.getNsteps();
@@ -1387,12 +1385,14 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
   // Get level data
   auto* ldata_p = getLevelDataPtr(a_lev, AmrNewTime);
 
-  // Determine if we need to fill from plotfile or if already filled by coarsening
+  // Determine if we need to fill from plotfile or if already filled by
+  // coarsening
   bool skip_plt_fill = false;
   int source_plt_level = a_lev; // Default: no level shift
-  
+
   if (m_initDataPlt_coarsen && m_level_shift > 0) {
-    // Coarser level 0 was already handled - data was filled by coarsenLevelFromPlt
+    // Coarser level 0 was already handled - data was filled by
+    // coarsenLevelFromPlt
     if (did_coarsen_base) {
       skip_plt_fill = true;
       if (m_verbose > 0) {
@@ -1402,9 +1402,9 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
       source_plt_level = a_lev - m_level_shift;
       // Direct mapping with level shift
       if (source_plt_level >= 0 && m_verbose > 0) {
-        amrex::Print() 
-          << "  Level " << a_lev << ": Reading from plotfile level " 
-          << source_plt_level << "\n";
+        amrex::Print() << "  Level " << a_lev
+                       << ": Reading from plotfile level " << source_plt_level
+                       << "\n";
       }
     }
   }
@@ -1415,115 +1415,122 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
       source_plt_level, geom[a_lev], idV, VELX, AMREX_SPACEDIM, ldata_p->state);
 
     // Temperature
-    pltData.fillPatchFromPlt(source_plt_level, geom[a_lev], idT, TEMP, 1, ldata_p->state);
+    pltData.fillPatchFromPlt(
+      source_plt_level, geom[a_lev], idT, TEMP, 1, ldata_p->state);
 
     // Species
     // Hold the species in temporary MF before copying to level data
     // in case the number of species differs.
     amrex::MultiFab speciesPlt(grids[a_lev], dmap[a_lev], nSpecPlt, 0);
-    pltData.fillPatchFromPlt(source_plt_level, geom[a_lev], idY, 0, nSpecPlt, speciesPlt);
-  for (int i = 0; i < NUM_SPECIES; ++i) {
-    std::string specName = "Y(" + spec_names[i] + ")";
-    std::string specString = specName;
-    if (!m_initDataPlt_specname_map.empty()) {
-      specString = m_initDataPlt_specname_map[i];
-    }
-    int foundSpec = 0;
-    for (int iplt = 0; iplt < nSpecPlt; ++iplt) {
-      if (specString == plt_vars[idY + iplt]) {
-        amrex::MultiFab::Copy(
-          ldata_p->state, speciesPlt, iplt, FIRSTSPEC + i, 1, 0);
-        foundSpec = 1;
-        if (m_verbose > 0) {
-          amrex::Print() << "Loading species " << specName
-                         << " from plotfile species " << specString << "\n";
-        }
+    pltData.fillPatchFromPlt(
+      source_plt_level, geom[a_lev], idY, 0, nSpecPlt, speciesPlt);
+    for (int i = 0; i < NUM_SPECIES; ++i) {
+      std::string specName = "Y(" + spec_names[i] + ")";
+      std::string specString = specName;
+      if (!m_initDataPlt_specname_map.empty()) {
+        specString = m_initDataPlt_specname_map[i];
       }
-    }
-    if (foundSpec == 0) {
-      for (int iplt = 0; iplt < plt_vars.size(); ++iplt) {
-        if (specString == plt_vars[iplt]) {
+      int foundSpec = 0;
+      for (int iplt = 0; iplt < nSpecPlt; ++iplt) {
+        if (specString == plt_vars[idY + iplt]) {
+          amrex::MultiFab::Copy(
+            ldata_p->state, speciesPlt, iplt, FIRSTSPEC + i, 1, 0);
           foundSpec = 1;
           if (m_verbose > 0) {
             amrex::Print() << "Loading species " << specName
-                           << " from plotfile entry " << specString << "\n";
+                           << " from plotfile species " << specString << "\n";
           }
-          pltData.fillPatchFromPlt(
-            source_plt_level, geom[a_lev], iplt, FIRSTSPEC + i, 1, ldata_p->state);
+        }
+      }
+      if (foundSpec == 0) {
+        for (int iplt = 0; iplt < plt_vars.size(); ++iplt) {
+          if (specString == plt_vars[iplt]) {
+            foundSpec = 1;
+            if (m_verbose > 0) {
+              amrex::Print() << "Loading species " << specName
+                             << " from plotfile entry " << specString << "\n";
+            }
+            pltData.fillPatchFromPlt(
+              source_plt_level, geom[a_lev], iplt, FIRSTSPEC + i, 1,
+              ldata_p->state);
+          }
+        }
+      }
+      if (foundSpec == 0) {
+        ldata_p->state.setVal(0.0, FIRSTSPEC + i, 1);
+        if (m_verbose > 0) {
+          amrex::Print() << "For species " << specName << " entry "
+                         << specString
+                         << " not found in plot file, setting to 0\n";
         }
       }
     }
-    if (foundSpec == 0) {
-      ldata_p->state.setVal(0.0, FIRSTSPEC + i, 1);
-      if (m_verbose > 0) {
-        amrex::Print() << "For species " << specName << " entry " << specString
-                       << " not found in plot file, setting to 0\n";
-      }
-    }
-  }
 
-  // Converting units when pltfile is coming from PeleC solution
-  if (pltfileSource == "C") {
-    amrex::Print() << " Converting CGS to MKS units... \n";
-    auto const& state_ma = ldata_p->state.arrays();
-    amrex::ParallelFor(
-      ldata_p->state, amrex::IntVect(0), AMREX_SPACEDIM,
-      [state_ma] AMREX_GPU_DEVICE(
-        int box_no, int i, int j, int k, int n) noexcept {
-        amrex::Array4<amrex::Real> vel(state_ma[box_no], VELX);
-        vel(i, j, k, n) *= 0.01;
-      });
-    amrex::Gpu::streamSynchronize();
-  }
+    // Converting units when pltfile is coming from PeleC solution
+    if (pltfileSource == "C") {
+      amrex::Print() << " Converting CGS to MKS units... \n";
+      auto const& state_ma = ldata_p->state.arrays();
+      amrex::ParallelFor(
+        ldata_p->state, amrex::IntVect(0), AMREX_SPACEDIM,
+        [state_ma] AMREX_GPU_DEVICE(
+          int box_no, int i, int j, int k, int n) noexcept {
+          amrex::Array4<amrex::Real> vel(state_ma[box_no], VELX);
+          vel(i, j, k, n) *= 0.01;
+        });
+      amrex::Gpu::streamSynchronize();
+    }
 
 #ifdef PELE_USE_PLASMA
     // nE
-    pltData.fillPatchFromPlt(source_plt_level, geom[a_lev], inE, NE, 1, ldata_p->state);
+    pltData.fillPatchFromPlt(
+      source_plt_level, geom[a_lev], inE, NE, 1, ldata_p->state);
     // phiV
-    pltData.fillPatchFromPlt(source_plt_level, geom[a_lev], iPhiV, PHIV, 1, ldata_p->state);
+    pltData.fillPatchFromPlt(
+      source_plt_level, geom[a_lev], iPhiV, PHIV, 1, ldata_p->state);
 #endif
 #ifdef PELE_USE_SOOT
     if (do_soot_solve) {
       if (inSoot >= 0) {
         pltData.fillPatchFromPlt(
-          source_plt_level, geom[a_lev], inSoot, FIRSTSOOT, NUMSOOTVAR, ldata_p->state);
-      if (pltfileSource == "C") {
-        SootConst sc;
-        amrex::Real* momV = sc.MomOrderV.data();
-        amrex::Real* momS = sc.MomOrderS.data();
-        auto const& state_ma = ldata_p->state.arrays();
-        amrex::Real soot_exp[NUM_SOOT_MOMENTS] = {0.0};
-        for (int n = 0; n < NUM_SOOT_MOMENTS; ++n) {
-          soot_exp[n] = 3. - (3. * momV[n] + 2. * momS[n]);
+          source_plt_level, geom[a_lev], inSoot, FIRSTSOOT, NUMSOOTVAR,
+          ldata_p->state);
+        if (pltfileSource == "C") {
+          SootConst sc;
+          amrex::Real* momV = sc.MomOrderV.data();
+          amrex::Real* momS = sc.MomOrderS.data();
+          auto const& state_ma = ldata_p->state.arrays();
+          amrex::Real soot_exp[NUM_SOOT_MOMENTS] = {0.0};
+          for (int n = 0; n < NUM_SOOT_MOMENTS; ++n) {
+            soot_exp[n] = 3. - (3. * momV[n] + 2. * momS[n]);
+          }
+          amrex::ParallelFor(
+            ldata_p->state, [state_ma, soot_exp] AMREX_GPU_DEVICE(
+                              int box_no, int i, int j, int k) noexcept {
+              amrex::Array4<amrex::Real> soot(state_ma[box_no], FIRSTSOOT);
+              for (int n = 0; n < NUM_SOOT_MOMENTS; ++n) {
+                soot(i, j, k, n) *= std::pow(100., soot_exp[n]);
+              }
+              soot(i, j, k, NUMSOOTVAR - 1) *= 1.E6;
+            });
+          amrex::Gpu::streamSynchronize();
         }
+      } else {
+        SootData* const sd = soot_model->getSootData();
+        amrex::Real moments[NUM_SOOT_MOMENTS + 1];
+        sd->initialSmallMomVals(moments);
+        auto const& state_ma = ldata_p->state.arrays();
         amrex::ParallelFor(
-          ldata_p->state, [state_ma, soot_exp] AMREX_GPU_DEVICE(
-                            int box_no, int i, int j, int k) noexcept {
+          ldata_p->state, amrex::IntVect(0), NUM_SOOT_MOMENTS + 1,
+          [state_ma, moments] AMREX_GPU_DEVICE(
+            int box_no, int i, int j, int k, int n) noexcept {
             amrex::Array4<amrex::Real> soot(state_ma[box_no], FIRSTSOOT);
-            for (int n = 0; n < NUM_SOOT_MOMENTS; ++n) {
-              soot(i, j, k, n) *= std::pow(100., soot_exp[n]);
-            }
-            soot(i, j, k, NUMSOOTVAR - 1) *= 1.E6;
+            soot(i, j, k, n) = moments[n];
           });
-        amrex::Gpu::streamSynchronize();
       }
-    } else {
-      SootData* const sd = soot_model->getSootData();
-      amrex::Real moments[NUM_SOOT_MOMENTS + 1];
-      sd->initialSmallMomVals(moments);
-      auto const& state_ma = ldata_p->state.arrays();
-      amrex::ParallelFor(
-        ldata_p->state, amrex::IntVect(0), NUM_SOOT_MOMENTS + 1,
-        [state_ma, moments] AMREX_GPU_DEVICE(
-          int box_no, int i, int j, int k, int n) noexcept {
-          amrex::Array4<amrex::Real> soot(state_ma[box_no], FIRSTSOOT);
-          soot(i, j, k, n) = moments[n];
-        });
     }
-  }
 #endif
   } // end if (!skip_plt_fill)
-  
+
   // Pressure and pressure gradients to zero
   ldata_p->press.setVal(0.0);
   ldata_p->gp.setVal(0.0);
@@ -1595,39 +1602,41 @@ PeleLM::computeLevelShift(
   // Compute coarsening ratio between plotfile level 0 and new level 0
   amrex::IntVect plt_domain_size = pltData.getGeom(0).Domain().size();
   amrex::IntVect new_domain_size = geom[0].Domain().size();
-  
+
   // Check if domains are identical (no coarsening)
   if (plt_domain_size == new_domain_size) {
     return 0;
   }
-  
+
   // Compute ratio in each direction
   amrex::IntVect ratio = plt_domain_size / new_domain_size;
-  
+
   // Validate ratio is isotropic
   for (int idim = 1; idim < AMREX_SPACEDIM; ++idim) {
     if (ratio[idim] != ratio[0]) {
       std::string ratio_str = "(";
       for (int d = 0; d < AMREX_SPACEDIM; ++d) {
         ratio_str += std::to_string(ratio[d]);
-        if (d < AMREX_SPACEDIM - 1) ratio_str += ", ";
+        if (d < AMREX_SPACEDIM - 1)
+          ratio_str += ", ";
       }
       ratio_str += ")";
       amrex::Abort(
         "peleLM.initDataPlt_coarsen: Coarsening ratio must be the same in all "
-        "directions. Found ratio: " + ratio_str);
+        "directions. Found ratio: " +
+        ratio_str);
     }
   }
-  
+
   int coarsen_factor = ratio[0];
-  
+
   // Check if new domain is actually coarser (ratio > 1)
   if (coarsen_factor < 1) {
     amrex::Abort(
       "peleLM.initDataPlt_coarsen: New level 0 domain is finer than plotfile "
       "level 0. This feature only supports coarsening, not refinement.");
   }
-  
+
   // Validate it's a power of 2 and within supported range (2, 4, 8)
   int level_shift = 0;
   if (coarsen_factor == 1) {
@@ -1640,12 +1649,14 @@ PeleLM::computeLevelShift(
     level_shift = 3;
   } else {
     amrex::Abort(
-      "peleLM.initDataPlt_coarsen: Coarsening ratio must be 2, 4, or 8. Found: " +
+      "peleLM.initDataPlt_coarsen: Coarsening ratio must be 2, 4, or 8. "
+      "Found: " +
       std::to_string(coarsen_factor));
   }
-  
+
   // Validate exact divisibility
-  amrex::IntVect remainder = plt_domain_size - (new_domain_size * coarsen_factor);
+  amrex::IntVect remainder =
+    plt_domain_size - (new_domain_size * coarsen_factor);
   if (remainder != amrex::IntVect::TheZeroVector()) {
     std::string plt_str = "(";
     std::string new_str = "(";
@@ -1661,18 +1672,19 @@ PeleLM::computeLevelShift(
     new_str += ")";
     amrex::Abort(
       "peleLM.initDataPlt_coarsen: Plotfile domain size must be exactly "
-      "divisible by new domain size. Plotfile: " + plt_str +
-      ", New: " + new_str +
+      "divisible by new domain size. Plotfile: " +
+      plt_str + ", New: " + new_str +
       ", Ratio: " + std::to_string(coarsen_factor));
   }
-  
+
   if (m_verbose > 0) {
-    amrex::Print() << "  peleLM.initDataPlt_coarsen: Detected " << coarsen_factor
+    amrex::Print() << "  peleLM.initDataPlt_coarsen: Detected "
+                   << coarsen_factor
                    << "x coarsening (level_shift=" << level_shift << ")\n";
     amrex::Print() << "  Plotfile level 0 domain: " << plt_domain_size << "\n";
     amrex::Print() << "  New level 0 domain: " << new_domain_size << "\n";
   }
-  
+
   return level_shift;
 }
 
@@ -1683,12 +1695,13 @@ PeleLM::coarsenLevelFromPlt(
   const amrex::IntVect& coarsen_ratio)
 {
   BL_PROFILE("PeleLMeX::coarsenLevelFromPlt()");
-  
+
   if (m_verbose > 0) {
-    amrex::Print() << "  Coarsening level " << a_lev << " from plotfile level 0 "
+    amrex::Print() << "  Coarsening level " << a_lev
+                   << " from plotfile level 0 "
                    << "with ratio " << coarsen_ratio << "\n";
   }
-  
+
 #ifdef AMREX_USE_EB
   if (!EBFactory(a_lev).isAllRegular()) {
     amrex::Abort(
@@ -1696,25 +1709,25 @@ PeleLM::coarsenLevelFromPlt(
       "This feature currently only works for non-EB cases.");
   }
 #endif
-  
+
   if (m_mesh_mapping) {
     amrex::Abort(
       "peleLM.initDataPlt_coarsen: Mesh mapping not supported. "
       "This feature currently only works without mesh mapping.");
   }
-  
+
   // Create temporary fine MultiFab matching plotfile level 0 resolution
   amrex::BoxArray fineBA = amrex::refine(grids[a_lev], coarsen_ratio);
   amrex::DistributionMapping fineDM(fineBA);
   amrex::MultiFab fineData(fineBA, fineDM, NVAR, 0);
-  
+
   // Fill fine data from plotfile level 0 using standard fillPatchFromPlt
   // This bypasses the coarsening restriction in PltFileManager
   amrex::Vector<std::string> spec_names;
   pele::physics::eos::speciesNames<pele::physics::PhysicsType::eos_type>(
     spec_names, &(eos_parms.host_parm()));
   amrex::Vector<std::string> plt_vars = pltData.getVariableList();
-  
+
   // Find required variable indices in plotfile
   int idT = -1, idV = -1, idY = -1;
   for (int i = 0; i < plt_vars.size(); ++i) {
@@ -1731,20 +1744,21 @@ PeleLM::coarsenLevelFromPlt(
       idY = i;
     }
   }
-  
+
   if (idT < 0 || idV < 0 || idY < 0) {
-    amrex::Abort("coarsenLevelFromPlt: Could not find required variables in plotfile");
+    amrex::Abort(
+      "coarsenLevelFromPlt: Could not find required variables in plotfile");
   }
-  
+
   // Create fine geometry for interpolation
   amrex::Geometry fineGeom = amrex::refine(geom[a_lev], coarsen_ratio);
-  
+
   // Fill velocity
   pltData.fillPatchFromPlt(0, fineGeom, idV, VELX, AMREX_SPACEDIM, fineData);
-  
-  // Fill temperature  
+
+  // Fill temperature
   pltData.fillPatchFromPlt(0, fineGeom, idT, TEMP, 1, fineData);
-  
+
   // Fill species
   int nSpecPlt = 0;
   for (int i = 0; i < plt_vars.size(); ++i) {
@@ -1752,10 +1766,10 @@ PeleLM::coarsenLevelFromPlt(
       nSpecPlt++;
     }
   }
-  
+
   amrex::MultiFab fineSpecies(fineBA, fineDM, nSpecPlt, 0);
   pltData.fillPatchFromPlt(0, fineGeom, idY, 0, nSpecPlt, fineSpecies);
-  
+
   // Map species to current mechanism
   for (int i = 0; i < NUM_SPECIES; ++i) {
     std::string specName = "Y(" + spec_names[i] + ")";
@@ -1763,7 +1777,7 @@ PeleLM::coarsenLevelFromPlt(
     if (!m_initDataPlt_specname_map.empty()) {
       specString = m_initDataPlt_specname_map[i];
     }
-    
+
     int foundSpec = 0;
     for (int iplt = 0; iplt < nSpecPlt; ++iplt) {
       if (specString == plt_vars[idY + iplt]) {
@@ -1772,7 +1786,7 @@ PeleLM::coarsenLevelFromPlt(
         break;
       }
     }
-    
+
     if (foundSpec == 0) {
       // Try searching full variable list
       for (int iplt = 0; iplt < plt_vars.size(); ++iplt) {
@@ -1785,25 +1799,26 @@ PeleLM::coarsenLevelFromPlt(
         }
       }
     }
-    
+
     if (foundSpec == 0) {
       fineData.setVal(0.0, FIRSTSPEC + i, 1, 0);
       if (m_verbose > 0) {
-        amrex::Print() << "  Species " << specName << " not found, setting to 0\n";
+        amrex::Print() << "  Species " << specName
+                       << " not found, setting to 0\n";
       }
     }
   }
-  
+
   // Get level data pointer
   auto* ldata_p = getLevelDataPtr(a_lev, AmrNewTime);
-  
+
   // Apply conservative averaging to coarsen data
   // Average down all state components
-  amrex::average_down(
-    fineData, ldata_p->state, 0, NVAR, coarsen_ratio);
-  
+  amrex::average_down(fineData, ldata_p->state, 0, NVAR, coarsen_ratio);
+
   if (m_verbose > 1) {
-    amrex::Print() << "  Conservative coarsening complete for level " << a_lev << "\n";
+    amrex::Print() << "  Conservative coarsening complete for level " << a_lev
+                   << "\n";
   }
 }
 

--- a/Source/PeleLMeX_Plot.cpp
+++ b/Source/PeleLMeX_Plot.cpp
@@ -1253,8 +1253,7 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
 
       if (m_level_shift > 0) {
         amrex::Print() << "  peleLM.initDataPlt_coarsen: Coarsening active\n";
-        amrex::Print()
-          << "  Plotfile level K will become new level K+1\n";
+        amrex::Print() << "  Plotfile level K will become new level K+1\n";
 
         // Verify we have enough plotfile levels
         if (finest_level - 1 > pltData.getNlev() - 1) {
@@ -1266,14 +1265,15 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
 
     // Coarsen from plotfile level 0 to new coarser level 0
     if (a_lev == 0 && m_level_shift > 0) {
-      coarsenLevelFromPlt(a_lev, pltData, amrex::IntVect(AMREX_D_DECL(2, 2, 2)));
+      coarsenLevelFromPlt(
+        a_lev, pltData, amrex::IntVect(AMREX_D_DECL(2, 2, 2)));
       did_coarsen_base = true;
     }
     // Intermediate levels don't have corresponding plotfile data - interpolate
     else if (a_lev > 0 && a_lev < m_level_shift) {
       if (m_verbose > 0) {
-        amrex::Print() << "  Level " << a_lev
-                       << ": Interpolating from level " << (a_lev - 1) << "\n";
+        amrex::Print() << "  Level " << a_lev << ": Interpolating from level "
+                       << (a_lev - 1) << "\n";
       }
 
       auto* ldata_p = getLevelDataPtr(a_lev, AmrNewTime);
@@ -1367,8 +1367,9 @@ PeleLM::initLevelDataFromPlt(int a_lev, const std::string& a_dataPltFile)
     } else {
       source_plt_level = a_lev - 1; // Read from previous plotfile level
       if (m_verbose > 0) {
-        amrex::Print() << "  Level " << a_lev << ": Reading from plotfile level "
-                       << source_plt_level << "\n";
+        amrex::Print() << "  Level " << a_lev
+                       << ": Reading from plotfile level " << source_plt_level
+                       << "\n";
       }
     }
   }

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -708,6 +708,7 @@ PeleLM::readParameters()
       "If specifying a species name map, length must equal number of species");
   }
   pp.query("initDataPlt_reset_time", m_do_reset_time);
+  pp.query("intDataPlt_coarsen", m_intDataPlt_coarsen);
 
   // -----------------------------------------
   // advance

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -708,7 +708,7 @@ PeleLM::readParameters()
       "If specifying a species name map, length must equal number of species");
   }
   pp.query("initDataPlt_reset_time", m_do_reset_time);
-  pp.query("intDataPlt_coarsen", m_intDataPlt_coarsen);
+  pp.query("initDataPlt_coarsen", m_initDataPlt_coarsen);
 
   // -----------------------------------------
   // advance


### PR DESCRIPTION
This PR adds support for restarting from a plt file with a 2x coarser base mesh via `peleLM.initDataPlt_coarsen`. This is useful for reducing computational cost when continuing a simulation. Currently this only works for Non-EB cases. 

This feature uses multi-level mapping so that plt file levels are shifted to match the new grid hierarchy. For example:  `plt_old` level 0 becomes the new level 1, `plt_old` level 1 becomes the new L2, etc. The base level is coarsened using conservative volume-weighted averaging and intermediate levels are created via interpolation from coarser levels.

I added an example in the HotBubble RegTest that demonstrates this capability.

Restarting HotBubble from t = 0.1 s with 2x coarser mesh
<img width="1305" height="801" alt="restart_coarser_level0_0 1s" src="https://github.com/user-attachments/assets/3cd04c6e-11c9-47f2-be17-f472db81b4cb" />

Resulting meshes at t = 0.15 s after restart at t = 0.1 s
<img width="1305" height="801" alt="restart_coarser_level0_0 15s" src="https://github.com/user-attachments/assets/774b22be-2b86-4abb-a382-b18932fac50b" />
