### PR TITLE
Mesh mapping: physical inflow positions, turbinflow guard, resolution report.

### DIFF
--- a/.codespell-ignore-words
+++ b/.codespell-ignore-words
@@ -4,3 +4,4 @@ commun
 inE
 nd
 ThirdParty
+statics

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -198,6 +198,14 @@ jobs:
         mpirun -n 2 ./PeleLMeX3d.gnu.DEBUG.MPI.ex input.3d_BoxLoZ peleLM.num_init_iter=1 amr.n_cell=32 32 32 amr.max_step=2 amr.plot_int=-1 amr.check_int=-1 amrex.abort_on_unused_inputs=1
         mpirun -n 2 ./PeleLMeX3d.gnu.DEBUG.MPI.ex input.3d_twoInjsOverlap peleLM.num_init_iter=1 amr.n_cell=32 32 32 amr.max_step=2 amr.plot_int=2 amr.check_int=-1 amrex.abort_on_unused_inputs=0
         ${GITHUB_WORKSPACE}/Submodules/PelePhysics/Submodules/amrex/Tools/Plotfile/fcompare.gnu.ex plt00002 pltoverlap00002
+        # Mesh mapping x turbulent inflow: the injected field must follow physical,
+        # not computational, transverse positions.  ConstantMap doubles x, so the
+        # mapped run and its unmapped reference share one physical mesh and their
+        # inflow-plane slices must agree (correlation ~1); the tanh case is a smoke test.
+        mpirun -n 2 ./PeleLMeX3d.gnu.DEBUG.MPI.ex input.3d_ConstantMap peleLM.num_init_iter=1 amrex.abort_on_unused_inputs=1
+        mpirun -n 2 ./PeleLMeX3d.gnu.DEBUG.MPI.ex input.3d_ConstantMap_ref peleLM.num_init_iter=1 amrex.abort_on_unused_inputs=1
+        python3 compare_inflow_plane.py planeCMref_000001 planeCM_000001 --map constant --beta 2 --require 0.99
+        mpirun -n 2 ./PeleLMeX3d.gnu.DEBUG.MPI.ex input.3d_TanhStretch peleLM.num_init_iter=1 amr.max_step=2 amr.plot_int=-1 amr.check_int=-1 amrex.abort_on_unused_inputs=1
     - name: Build Vortex Test
       working-directory: ./Exec/RegTests/PeriodicCases/
       run: |

--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -360,10 +360,16 @@ Mesh Mapping
    aborts at setup if the two are combined without it, rather than silently
    sampling the file at :math:`\xi` positions.
 
-   The turbulence *file* is always uniformly spaced -- its header carries only
-   a point count and a domain size per direction -- so only the target grid may
-   be stretched. Turbulence generated **on** a stretched mesh cannot be
-   represented in the format and is not supported. At ``peleLM.v > 0`` a
+   The turbulence *file* is uniformly spaced in *some* coordinate -- its
+   header carries only a point count and a domain size per direction. Synthetic
+   data and planes from a uniform-mesh precursor are uniform in physical
+   position, which is what the sampling path assumes, so only the target grid
+   may be stretched. Planes extracted from a precursor that itself ran with
+   ``mesh_mapping`` are uniform in that run's :math:`\xi` coordinate instead;
+   the `PelePhysics` reader recognises such files by an optional ``MESHMAP_V1``
+   trailer in the ``HDR`` and refuses them until the sampling path can invert
+   the file's map. Do not inject planes from a mapped precursor before that
+   lands. At ``peleLM.v > 0`` a
    resolution check prints, per inflow face, the range of the grid's physical
    spacing against the file's spacing; a ratio well above one means the file
    cannot fill the scales the stretched grid resolves near its clustering, and

--- a/Docs/sphinx/manual/LMeXControls.rst
+++ b/Docs/sphinx/manual/LMeXControls.rst
@@ -338,7 +338,37 @@ Mesh Mapping
 .. note::
    Three mesh maps are provided with `PeleLMeX.  If `mesh_mapping` is not specified, no mapping will be applied. Each map has associated
    parameters shown above.
-   
+
+.. note::
+   **Physical vs. computational coordinates.** With a mapping active, the AMReX
+   grid is the uniform computational (:math:`\xi`) grid and the physical grid is
+   its image under the map. Inputs that name a *position* are physical
+   coordinates and are converted internally: ``peleLM.inlet_plane_position``
+   (the recycling source plane) is inverted through the map before being turned
+   into an index, and its bounds check is against the physical domain extent,
+   which for ``ConstantMap`` differs from ``geometry.prob_lo`` /
+   ``geometry.prob_hi``. Diagnostics inherited from `PelePhysics`, notably
+   ``DiagFramePlane``, are the exception: their ``center`` is located on the
+   AMReX grid and is therefore a :math:`\xi` coordinate.
+
+.. note::
+   **Turbulent inflow.** ``turbinflow`` may be combined with ``mesh_mapping``:
+   the injection face's physical cell-centre positions are handed to
+   `PelePhysics` explicitly, so the turbulence file is sampled at the right
+   place on a stretched grid. This requires a `PelePhysics` new enough to
+   provide the coordinate-based ``TurbInflow::add_turb()`` overload; PeleLMeX
+   aborts at setup if the two are combined without it, rather than silently
+   sampling the file at :math:`\xi` positions.
+
+   The turbulence *file* is always uniformly spaced -- its header carries only
+   a point count and a domain size per direction -- so only the target grid may
+   be stretched. Turbulence generated **on** a stretched mesh cannot be
+   represented in the format and is not supported. At ``peleLM.v > 0`` a
+   resolution check prints, per inflow face, the range of the grid's physical
+   spacing against the file's spacing; a ratio well above one means the file
+   cannot fill the scales the stretched grid resolves near its clustering, and
+   well below one means the injected field is aliased.
+
 
 Turbulent Forcing and Velocity Plotfile
 ---------------------------------------

--- a/Exec/RegTests/TurbInflow/compare_inflow_plane.py
+++ b/Exec/RegTests/TurbInflow/compare_inflow_plane.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Compare a DiagFramePlane slice from a mesh-mapped run against the same
+slice from an unmapped run, to check that turbulent inflow is sampled at
+PHYSICAL transverse positions.
+
+usage:
+  compare_inflow_plane.py <uniform_plane_dir> <mapped_plane_dir> \
+      [--map tanh|constant] [--beta 2.0] [--field x_velocity] \
+      [--require 0.99] [--plot out.png]
+
+Both plane directories are 2D AMReX plotfiles written by PelePhysics'
+DiagFramePlane (normal = 2, so plane axes are x, y).  The mapped run's plane
+carries Xi (computational) coordinates; the script maps them to physical x
+(TanhStretchMap or ConstantMap in x, parameter --beta) and interpolates the
+uniform run onto those positions.  Each run's x extent comes from its own
+Header, so the two domains may differ in size (ConstantMap).  Two
+hypotheses are scored:
+
+  H_phys : mapped(x_phys_i) == uniform(x_phys_i)   <- correct sampling
+  H_xi   : mapped(x_phys_i) == uniform(xi_i)       <- the pre-fix bug
+
+Correlation near 1 for H_phys and clearly lower for H_xi is a pass.  With
+--require C the script exits non-zero unless the mean H_phys correlation is
+at least C and exceeds the H_xi one by at least 0.2, so it can gate CI.
+"""
+import argparse
+import os
+import re
+import sys
+
+import numpy as np
+
+
+# --------------------------------------------------------------------------
+# Minimal reader for a single-level 2D AMReX plotfile (VisMF v1, native double)
+# --------------------------------------------------------------------------
+def read_plotfile_header(pltdir):
+    with open(os.path.join(pltdir, "Header")) as f:
+        lines = [ln.rstrip("\n") for ln in f]
+    nvar = int(lines[1])
+    varnames = lines[2 : 2 + nvar]
+    p = 2 + nvar
+    spacedim = int(lines[p]); p += 1
+    time = float(lines[p]); p += 1
+    finest = int(lines[p]); p += 1
+    problo = [float(v) for v in lines[p].split()]; p += 1
+    probhi = [float(v) for v in lines[p].split()]; p += 1
+    p += 1  # ref ratios
+    dom = re.findall(r"\(\((-?\d+),(-?\d+)(?:,-?\d+)?\) \((-?\d+),(-?\d+)(?:,-?\d+)?\)", lines[p])[0]
+    domain = tuple(int(v) for v in dom)
+    return dict(varnames=varnames, spacedim=spacedim, time=time, finest=finest,
+                problo=problo, probhi=probhi, domain=domain)
+
+
+def read_level0(pltdir, ncomp_expected=None):
+    lev = os.path.join(pltdir, "Level_0")
+    with open(os.path.join(lev, "Cell_H")) as f:
+        txt = f.read()
+    ncomp = int(txt.splitlines()[2])
+    boxes = re.findall(r"\(\((-?\d+),(-?\d+)(?:,-?\d+)?\) \((-?\d+),(-?\d+)(?:,-?\d+)?\)", txt)
+    fabs = re.findall(r"FabOnDisk:\s+(\S+)\s+(\d+)", txt)
+    if len(fabs) == 0:
+        sys.exit("no FabOnDisk entries in " + os.path.join(lev, "Cell_H"))
+    boxes = boxes[: len(fabs)]  # box list precedes the FabOnDisk list
+    return ncomp, [tuple(int(v) for v in b) for b in boxes], fabs
+
+
+def read_fab(path, offset, ncomp):
+    with open(path, "rb") as f:
+        f.seek(offset)
+        hdr = b""
+        while not hdr.endswith(b"\n"):
+            c = f.read(1)
+            if not c:
+                sys.exit("unexpected EOF reading FAB header in " + path)
+            hdr += c
+        h = hdr.decode()
+        m = re.search(r"\(\((-?\d+),(-?\d+)(?:,-?\d+)?\) \((-?\d+),(-?\d+)(?:,-?\d+)?\)", h)
+        ilo, jlo, ihi, jhi = (int(v) for v in m.groups())
+        nc = int(h.strip().split()[-1])
+        if ncomp_mismatch(nc, ncomp):
+            sys.exit(f"FAB ncomp {nc} != Cell_H ncomp {ncomp}")
+        nx, ny = ihi - ilo + 1, jhi - jlo + 1
+        # Data descriptor "(8, (64 11 52 0 1 12 0 4))" is IEEE double; assume
+        # native little-endian, which is what a Mac/Linux build writes.
+        data = np.frombuffer(f.read(8 * nx * ny * nc), dtype="<f8")
+        arr = data.reshape((nc, ny, nx)).transpose(0, 2, 1)  # -> [c, i, j]
+        return (ilo, jlo, ihi, jhi), arr
+
+
+def ncomp_mismatch(a, b):
+    return b is not None and a != b
+
+
+def load_plane(pltdir):
+    hdr = read_plotfile_header(pltdir)
+    ilo, jlo, ihi, jhi = hdr["domain"]
+    nx, ny = ihi - ilo + 1, jhi - jlo + 1
+    ncomp, boxes, fabs = read_level0(pltdir)
+    full = np.full((ncomp, nx, ny), np.nan)
+    for (bilo, bjlo, bihi, bjhi), (fname, off) in zip(boxes, fabs):
+        fbox, arr = read_fab(os.path.join(pltdir, "Level_0", fname), int(off), ncomp)
+        a, b, c, d = fbox
+        full[:, a - ilo : c - ilo + 1, b - jlo : d - jlo + 1] = arr
+    if np.isnan(full).any():
+        sys.exit("plane not fully covered by FABs in " + pltdir)
+    return hdr, full
+
+
+# --------------------------------------------------------------------------
+def tanh_map(xi, plo, L, beta):
+    if abs(beta) < 1e-8:
+        return xi
+    eta = (xi - plo) / L
+    return plo + L * 0.5 * (1.0 + np.tanh(beta * (2.0 * eta - 1.0)) / np.tanh(beta))
+
+
+def constant_map(xi, plo, L, fac):
+    return plo + fac * (xi - plo)
+
+
+def periodic_interp(xq, x, f, plo, L):
+    """Linear interpolation of f(x) (uniform, periodic on [plo, plo+L)) at xq."""
+    xx = np.concatenate([x - L, x, x + L])
+    ff = np.concatenate([f, f, f])
+    return np.interp(xq, xx, ff)
+
+
+def score(a, b):
+    a = a - a.mean(); b = b - b.mean()
+    corr = (a * b).sum() / np.sqrt((a * a).sum() * (b * b).sum())
+    rel_rms = np.sqrt(((a - b) ** 2).mean()) / np.sqrt((b * b).mean())
+    return corr, rel_rms
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("uniform")
+    ap.add_argument("stretched")
+    ap.add_argument("--map", choices=["tanh", "constant"], default="tanh",
+                    help="mapping of the stretched run in x")
+    ap.add_argument("--beta", type=float, default=2.0,
+                    help="TanhStretchMap beta in x, or ConstantMap scaling factor in x")
+    ap.add_argument("--field", default="x_velocity")
+    ap.add_argument("--plot", default=None, help="write a PNG of one row (needs matplotlib)")
+    ap.add_argument("--require", type=float, default=None,
+                    help="exit 1 unless mean H_phys corr >= this and beats H_xi by 0.2")
+    args = ap.parse_args()
+
+    hu, du = load_plane(args.uniform)
+    hs, ds = load_plane(args.stretched)
+    if hu["varnames"] != hs["varnames"]:
+        sys.exit("variable lists differ between the two planes")
+    if du.shape != ds.shape:
+        sys.exit(f"plane shapes differ: {du.shape} vs {ds.shape}")
+    ic = hu["varnames"].index(args.field)
+    nx, ny = du.shape[1:]
+    # stretched run: Xi grid from its own header, mapped to physical x
+    plo_s = hs["problo"][0]; L_s = hs["probhi"][0] - plo_s
+    xi = plo_s + (np.arange(nx) + 0.5) * (L_s / nx)
+    xph = tanh_map(xi, plo_s, L_s, args.beta) if args.map == "tanh" \
+        else constant_map(xi, plo_s, L_s, args.beta)
+    # uniform run: its own (physical) grid, periodic in x
+    plo_u = hu["problo"][0]; L_u = hu["probhi"][0] - plo_u
+    xu = plo_u + (np.arange(nx) + 0.5) * (L_u / nx)
+
+    print(f"field {args.field}: {nx} x {ny} plane, time uniform={hu['time']:.6g} stretched={hs['time']:.6g}")
+    print(f"{args.map} map, param={args.beta}: x_phys - xi displacement max = {np.abs(xph - xi).max():.4g} "
+          f"({np.abs(xph - xi).max() / (L_u / nx):.2f} uniform cells); physical extent "
+          f"stretched [{xph.min():.4g},{xph.max():.4g}] vs uniform [{xu.min():.4g},{xu.max():.4g}]")
+
+    cp, rp, cx, rx = [], [], [], []
+    for j in range(ny):
+        us = ds[ic, :, j]
+        uu = du[ic, :, j]
+        u_at_xph = periodic_interp(xph, xu, uu, plo_u, L_u)  # H_phys
+        u_at_xi = periodic_interp(xi, xu, uu, plo_u, L_u)    # H_xi
+        c1, r1 = score(us, u_at_xph); c2, r2 = score(us, u_at_xi)
+        cp.append(c1); rp.append(r1); cx.append(c2); rx.append(r2)
+    cp, rp, cx, rx = map(np.array, (cp, rp, cx, rx))
+    print("\n  hypothesis                corr (mean, min)      rel. rms diff (mean)")
+    print(f"  H_phys (correct sampling) {cp.mean():8.4f} {cp.min():8.4f}      {rp.mean():8.4f}")
+    print(f"  H_xi   (pre-fix bug)      {cx.mean():8.4f} {cx.min():8.4f}      {rx.mean():8.4f}")
+    thresh = args.require if args.require is not None else 0.9
+    ok = cp.mean() >= thresh and (cp.mean() - cx.mean()) > 0.2
+    if ok:
+        print(f"\n  => PASS: mapped-run plane matches the uniform run at physical x")
+    else:
+        print(f"\n  => FAIL: H_phys corr {cp.mean():.4f} (need >= {thresh}) and "
+              f"separation from H_xi {cp.mean() - cx.mean():.4f} (need > 0.2)")
+
+    if args.plot:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        j = ny // 2
+        fig, ax = plt.subplots(2, 1, figsize=(7, 6), sharex=True)
+        ax[0].plot(xu, du[ic, :, j], "k.-", label="uniform run vs x")
+        ax[0].plot(xph, ds[ic, :, j], "r.-", label="stretched run vs x_phys")
+        ax[0].set_title(f"{args.field}, row j={j}: H_phys (should overlay)")
+        ax[0].legend()
+        ax[1].plot(xu, du[ic, :, j], "k.-", label="uniform run vs x")
+        ax[1].plot(xi, ds[ic, :, j], "b.-", label="stretched run vs xi")
+        ax[1].set_title("H_xi (should NOT overlay)")
+        ax[1].legend(); ax[1].set_xlabel("x")
+        fig.tight_layout(); fig.savefig(args.plot, dpi=120)
+        print(f"  plot written to {args.plot}")
+
+    if args.require is not None and not ok:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Exec/RegTests/TurbInflow/input.3d_ConstantMap
+++ b/Exec/RegTests/TurbInflow/input.3d_ConstantMap
@@ -1,0 +1,92 @@
+# Turbulent inflow on a ConstantMap mesh: equivalence test.
+#
+# The Xi domain is 0.01 m wide in x and ConstantMap doubles it, so the
+# physical mesh is identical, cell for cell, to input.3d_ConstantMap_ref
+# (an unmapped run on a 0.02 m wide domain with the same n_cell).  The two
+# runs must therefore inject the same turbulence at the same physical
+# positions, and detJ/fac_z = 2 on the inflow face exercises the metric
+# scaling of the inflow boundary values in the nodal projection.
+#
+# Both cases dump the first interior cell layer above the inflow face every
+# step; compare them with
+#
+#   compare_inflow_plane.py planeCMref_000001 planeCM_000001 \
+#       --map constant --beta 2 --require 0.99
+#
+# which scores the mapped plane against the reference at physical x (must
+# correlate to ~1) and, for contrast, against the reference at Xi (the
+# pre-fix sampling; correlates poorly).  Compare an early step: the two
+# runs are not identical discretisations (metric factor vs anisotropic
+# computational cell), and the interior solutions drift apart by a few
+# percent per step, which is a separate question from where the inflow
+# is sampled.
+
+#----------------------DOMAIN DEFINITION------------------------
+geometry.is_periodic = 1 1 0              # For each dir, 0: non-perio, 1: periodic
+geometry.coord_sys   = 0                  # 0 => cart, 1 => RZ
+geometry.prob_lo     = 0.0 0.0 0.0        # x_lo y_lo (z_lo), Xi space
+geometry.prob_hi     = 0.01 0.01 0.01     # x_hi y_hi (z_hi), Xi space
+
+#-----------------------Mesh Mapping ---------------------------
+geometry.mesh_mapping      = ConstantMap
+ConstantMap.scaling_factor = 2.0 1.0 1.0  # physical x spans 0.02 m
+
+# >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+# Interior, Inflow, Outflow, Symmetry,
+# SlipWallAdiab, NoSlipWallAdiab, SlipWallIsotherm, NoSlipWallIsotherm
+peleLM.lo_bc = Interior Interior Inflow
+peleLM.hi_bc = Interior Interior Outflow
+
+#-------------------------AMR CONTROL----------------------------
+amr.n_cell          = 32 32 32          # Level 0 number of cells in each direction
+amr.v               = 1                 # AMR verbose
+amr.max_level       = 0                 # single level
+amr.blocking_factor = 8                 # block factor in grid generation
+amr.max_grid_size   = 16                # max box size
+
+#--------------------------- Problem -------------------------------
+prob.T_mean = 298.0
+prob.P_mean = 101325.0
+prob.flowDir = 2
+prob.flowMag = 5
+
+# The HIT file spans 2*pi in its own units; scale it over the 0.02 m
+# physical width (2*pi/0.02) and centre it in physical coordinates.
+turbinflows = lowZ
+turbinflow.lowZ.turb_file      = TurbFileHIT/TurbTEST
+turbinflow.lowZ.dir            = 2
+turbinflow.lowZ.side           = low
+turbinflow.lowZ.turb_scale_loc = 314.159
+turbinflow.lowZ.turb_scale_vel = 0.5
+turbinflow.lowZ.turb_center    = 0.01 0.005
+turbinflow.lowZ.turb_conv_vel  = 5.
+turbinflow.lowZ.turb_nplane    = 32
+turbinflow.lowZ.verbose        = 1
+
+#-------------------------PeleLM CONTROL----------------------------
+peleLM.v = 1
+peleLM.incompressible = 0
+peleLM.sdc_iterMax = 1
+peleLM.floor_species = 0
+peleLM.num_divu_iter = 1
+peleLM.num_init_iter = 1
+
+# Slice through the first interior cell layer above the inflow face, every
+# step.  Linear interpolation with center at the cell centre puts unit
+# weight on that layer (the Quadratic option samples one cell low).
+peleLM.diagnostics = inflowPlane
+peleLM.inflowPlane.type          = DiagFramePlane
+peleLM.inflowPlane.file          = planeCM_
+peleLM.inflowPlane.normal        = 2
+peleLM.inflowPlane.center        = 1.5625e-4
+peleLM.inflowPlane.interpolation = Linear
+peleLM.inflowPlane.int           = 1
+peleLM.inflowPlane.field_names   = x_velocity y_velocity z_velocity
+
+amr.plot_int = -1
+amr.check_int = -1
+amr.max_step = 2
+amr.fixed_dt = 2.e-5
+amr.derive_plot_vars = avg_pressure mag_vort mass_fractions
+
+fabarray.mfiter_tile_size = 1024 1024 1024

--- a/Exec/RegTests/TurbInflow/input.3d_ConstantMap_ref
+++ b/Exec/RegTests/TurbInflow/input.3d_ConstantMap_ref
@@ -1,0 +1,79 @@
+# Reference for input.3d_ConstantMap: the same physical mesh written out
+# directly (0.02 m wide in x).  See that file for the test.
+#
+# The physical cells are 2:1:1, and PeleLMeX asserts an isotropic grid
+# unless geometry.mesh_mapping is set, so the reference runs through the
+# mapped code path with an identity ConstantMap.  That makes the pair a
+# clean equivalence: same physical mesh, same operators, and the only
+# difference is whether the 2:1 aspect ratio comes from the metric
+# (fac_x = 2) or from the computational cell size itself.
+
+#----------------------DOMAIN DEFINITION------------------------
+geometry.is_periodic = 1 1 0              # For each dir, 0: non-perio, 1: periodic
+geometry.coord_sys   = 0                  # 0 => cart, 1 => RZ
+geometry.prob_lo     = 0.0 0.0 0.0        # x_lo y_lo (z_lo)
+geometry.prob_hi     = 0.02 0.01 0.01     # x_hi y_hi (z_hi)
+
+#-----------------------Mesh Mapping ---------------------------
+geometry.mesh_mapping      = ConstantMap
+ConstantMap.scaling_factor = 1.0 1.0 1.0  # identity; see header
+
+# >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+# Interior, Inflow, Outflow, Symmetry,
+# SlipWallAdiab, NoSlipWallAdiab, SlipWallIsotherm, NoSlipWallIsotherm
+peleLM.lo_bc = Interior Interior Inflow
+peleLM.hi_bc = Interior Interior Outflow
+
+#-------------------------AMR CONTROL----------------------------
+amr.n_cell          = 32 32 32          # Level 0 number of cells in each direction
+amr.v               = 1                 # AMR verbose
+amr.max_level       = 0                 # single level
+amr.blocking_factor = 8                 # block factor in grid generation
+amr.max_grid_size   = 16                # max box size
+
+#--------------------------- Problem -------------------------------
+prob.T_mean = 298.0
+prob.P_mean = 101325.0
+prob.flowDir = 2
+prob.flowMag = 5
+
+# The HIT file spans 2*pi in its own units; scale it over the 0.02 m
+# physical width (2*pi/0.02) and centre it in physical coordinates.
+turbinflows = lowZ
+turbinflow.lowZ.turb_file      = TurbFileHIT/TurbTEST
+turbinflow.lowZ.dir            = 2
+turbinflow.lowZ.side           = low
+turbinflow.lowZ.turb_scale_loc = 314.159
+turbinflow.lowZ.turb_scale_vel = 0.5
+turbinflow.lowZ.turb_center    = 0.01 0.005
+turbinflow.lowZ.turb_conv_vel  = 5.
+turbinflow.lowZ.turb_nplane    = 32
+turbinflow.lowZ.verbose        = 1
+
+#-------------------------PeleLM CONTROL----------------------------
+peleLM.v = 1
+peleLM.incompressible = 0
+peleLM.sdc_iterMax = 1
+peleLM.floor_species = 0
+peleLM.num_divu_iter = 1
+peleLM.num_init_iter = 1
+
+# Slice through the first interior cell layer above the inflow face, every
+# step.  Linear interpolation with center at the cell centre puts unit
+# weight on that layer (the Quadratic option samples one cell low).
+peleLM.diagnostics = inflowPlane
+peleLM.inflowPlane.type          = DiagFramePlane
+peleLM.inflowPlane.file          = planeCMref_
+peleLM.inflowPlane.normal        = 2
+peleLM.inflowPlane.center        = 1.5625e-4
+peleLM.inflowPlane.interpolation = Linear
+peleLM.inflowPlane.int           = 1
+peleLM.inflowPlane.field_names   = x_velocity y_velocity z_velocity
+
+amr.plot_int = -1
+amr.check_int = -1
+amr.max_step = 2
+amr.fixed_dt = 2.e-5
+amr.derive_plot_vars = avg_pressure mag_vort mass_fractions
+
+fabarray.mfiter_tile_size = 1024 1024 1024

--- a/Exec/RegTests/TurbInflow/input.3d_TanhStretch
+++ b/Exec/RegTests/TurbInflow/input.3d_TanhStretch
@@ -1,0 +1,69 @@
+# Turbulent inflow onto a transversely stretched mesh.
+#
+# Same setup as input.3d (HIT turbulence injected on the low-z face) but with
+# a tanh mesh mapping applied to x only.  y is left uniform as a control: the
+# injected field must be identical in y to the unmapped run and must follow
+# the *physical* x positions, not the computational (Xi) ones.  Getting this
+# wrong shifts the turbulence pattern in x, most visibly near the domain
+# centre where the mapping displaces cell centres the furthest.
+#
+# Single level and a short run: this is a smoke/behaviour case, not a
+# convergence test.
+
+#----------------------DOMAIN DEFINITION------------------------
+geometry.is_periodic = 1 1 0              # For each dir, 0: non-perio, 1: periodic
+geometry.coord_sys   = 0                  # 0 => cart, 1 => RZ
+geometry.prob_lo     = 0.0 0.0 0.0        # x_lo y_lo (z_lo)
+geometry.prob_hi     = 0.01 0.01 0.01     # x_hi y_hi (z_hi)
+
+#-----------------------Mesh Mapping ---------------------------
+geometry.mesh_mapping = TanhStretchMap
+TanhStretchMap.beta   = 2.0 0.0 0.0       # stretch x only; y and z uniform
+
+# >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
+# Interior, Inflow, Outflow, Symmetry,
+# SlipWallAdiab, NoSlipWallAdiab, SlipWallIsotherm, NoSlipWallIsotherm
+peleLM.lo_bc = Interior Interior Inflow
+peleLM.hi_bc = Interior Interior Outflow
+
+#-------------------------AMR CONTROL----------------------------
+amr.n_cell          = 32 32 32          # Level 0 number of cells in each direction
+amr.v               = 1                 # AMR verbose
+amr.max_level       = 0                 # single level
+amr.regrid_int      = 2                 # how often to regrid
+amr.blocking_factor = 8                 # block factor in grid generation
+amr.max_grid_size   = 16                # max box size
+
+#--------------------------- Problem -------------------------------
+prob.T_mean = 298.0
+prob.P_mean = 101325.0
+prob.flowDir = 2
+prob.flowMag = 5
+
+turbinflows = lowZ
+turbinflow.lowZ.turb_file      = TurbFileHIT/TurbTEST
+turbinflow.lowZ.dir            = 2
+turbinflow.lowZ.side           = low
+turbinflow.lowZ.turb_scale_loc = 628.319
+turbinflow.lowZ.turb_scale_vel = 0.5
+turbinflow.lowZ.turb_center    = 0.005 0.005
+turbinflow.lowZ.turb_conv_vel  = 5.
+turbinflow.lowZ.turb_nplane    = 32
+turbinflow.lowZ.verbose        = 1
+
+#-------------------------PeleLM CONTROL----------------------------
+peleLM.v = 1
+peleLM.incompressible = 0
+peleLM.sdc_iterMax = 1
+peleLM.floor_species = 0
+peleLM.num_divu_iter = 1
+peleLM.num_init_iter = 1
+
+amr.plot_int = 20
+amr.max_step = 40
+amr.dt_shrink = 0.1
+amr.stop_time = 0.02
+amr.cfl = 0.5
+amr.derive_plot_vars = avg_pressure mag_vort mass_fractions
+
+fabarray.mfiter_tile_size = 1024 1024 1024

--- a/Exec/RegTests/TurbInflow/input.3d_TanhStretch
+++ b/Exec/RegTests/TurbInflow/input.3d_TanhStretch
@@ -7,11 +7,18 @@
 # wrong shifts the turbulence pattern in x, most visibly near the domain
 # centre where the mapping displaces cell centres the furthest.
 #
+# x is bounded by slip walls rather than periodic: a tanh map clusters cells
+# at both ends of the axis, which is the physically meaningful configuration
+# for walls and an inconsistent one for a periodic seam (the metric has a
+# kink there, and the mapped nodal projection does not converge against it).
+#
 # Single level and a short run: this is a smoke/behaviour case, not a
-# convergence test.
+# convergence test.  For a quantitative check of the physical-position
+# sampling see input.3d_ConstantMap / input.3d_ConstantMap_ref and
+# compare_inflow_plane.py.
 
 #----------------------DOMAIN DEFINITION------------------------
-geometry.is_periodic = 1 1 0              # For each dir, 0: non-perio, 1: periodic
+geometry.is_periodic = 0 1 0              # x: slip walls (see header), y periodic
 geometry.coord_sys   = 0                  # 0 => cart, 1 => RZ
 geometry.prob_lo     = 0.0 0.0 0.0        # x_lo y_lo (z_lo)
 geometry.prob_hi     = 0.01 0.01 0.01     # x_hi y_hi (z_hi)
@@ -23,14 +30,13 @@ TanhStretchMap.beta   = 2.0 0.0 0.0       # stretch x only; y and z uniform
 # >>>>>>>>>>>>>  BC FLAGS <<<<<<<<<<<<<<<<
 # Interior, Inflow, Outflow, Symmetry,
 # SlipWallAdiab, NoSlipWallAdiab, SlipWallIsotherm, NoSlipWallIsotherm
-peleLM.lo_bc = Interior Interior Inflow
-peleLM.hi_bc = Interior Interior Outflow
+peleLM.lo_bc = SlipWallAdiab Interior Inflow
+peleLM.hi_bc = SlipWallAdiab Interior Outflow
 
 #-------------------------AMR CONTROL----------------------------
 amr.n_cell          = 32 32 32          # Level 0 number of cells in each direction
 amr.v               = 1                 # AMR verbose
 amr.max_level       = 0                 # single level
-amr.regrid_int      = 2                 # how often to regrid
 amr.blocking_factor = 8                 # block factor in grid generation
 amr.max_grid_size   = 16                # max box size
 

--- a/Source/Mesh/PeleLMeX_MeshMapEvaluator.H
+++ b/Source/Mesh/PeleLMeX_MeshMapEvaluator.H
@@ -2,6 +2,7 @@
 #define PELELMEX_MESHMAP_EVALUATOR_H
 
 #include <AMReX.H>
+#include <AMReX_Algorithm.H>
 #include <AMReX_BLassert.H>
 #include <AMReX_Geometry.H>
 #include <AMReX_GpuQualifiers.H>
@@ -310,6 +311,127 @@ struct MeshMapEvaluator
   }
 
   /**
+   * \brief Physical width of the cell with integer index \p idx along
+   *        axis \p idir.
+   *
+   * Exact for every supported map (it differences the two bounding face
+   * positions rather than assuming a local stretch factor).  Reduces to
+   * \c gd.CellSize()[idir] for \c Kind::Identity.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real
+  dx_phys_cc(int idir, int idx, amrex::GeometryData const& gd) const noexcept
+  {
+    return x_phys_face(idir, idx + 1, gd) - x_phys_face(idir, idx, gd);
+  }
+
+  /**
+   * \brief Inverse of \c x_phys_from_xi: the \f$\xi\f$-space coordinate
+   *        whose image under the mapping is \p x_phys, along axis \p idir.
+   *
+   * Constant, ExpStretch and TanhStretch invert in closed form (\c log and
+   * \c atanh).  InteriorStretch does not -- its offset involves
+   * \f$\eta + \sinh(2\beta\eta)/(2\beta)\f$ -- so it is inverted by a
+   * safeguarded Newton iteration on the monotone forward map, whose
+   * derivative is exactly \c interior_fac.  Use it to turn a physical
+   * position supplied in the inputs (a sampling-plane location, a probe
+   * position) into the coordinate that indexes the AMReX grid.
+   *
+   * \p x_phys is clamped to the physical image of \c [ProbLo, ProbHi]
+   * along \p idir, which keeps the \c log / \c atanh arguments in range;
+   * positions outside the domain are not meaningful for the callers this
+   * serves.  Callers that need a periodic image (e.g. a tiled inflow
+   * lookup) must wrap \p x_phys into the domain before calling.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE amrex::Real xi_from_x_phys(
+    int idir, amrex::Real x_phys, amrex::GeometryData const& gd) const noexcept
+  {
+    const amrex::Real plo = gd.ProbLo()[idir];
+    const amrex::Real L = gd.ProbHi()[idir] - plo;
+    switch (m_kind) {
+    case Kind::Identity:
+      return x_phys;
+
+    case Kind::Constant:
+      return plo + (x_phys - plo) / m_p[idir];
+
+    case Kind::ExpStretch: {
+      const amrex::Real beta = m_p[idir];
+      if (std::abs(beta) < BETA_EPS) {
+        return x_phys;
+      }
+      amrex::Real off = clamp01((x_phys - plo) / L);
+      if (m_q[idir] == 1) {
+        off = amrex::Real(1.0) - off;
+      }
+      const amrex::Real den = std::exp(beta) - amrex::Real(1.0);
+      amrex::Real eta = std::log(off * den + amrex::Real(1.0)) / beta;
+      if (m_q[idir] == 1) {
+        eta = amrex::Real(1.0) - eta;
+      }
+      return plo + L * eta;
+    }
+
+    case Kind::TanhStretch: {
+      const amrex::Real beta = m_p[idir];
+      if (std::abs(beta) < BETA_EPS) {
+        return x_phys;
+      }
+      const amrex::Real off = clamp01((x_phys - plo) / L);
+      // off in [0,1] puts the argument in [-tanh(beta), tanh(beta)], which
+      // is strictly inside atanh's domain for any finite beta.
+      const amrex::Real arg =
+        (amrex::Real(2.0) * off - amrex::Real(1.0)) * std::tanh(beta);
+      const amrex::Real eta =
+        amrex::Real(0.5) * (amrex::Real(1.0) + std::atanh(arg) / beta);
+      return plo + L * eta;
+    }
+
+    case Kind::InteriorStretch: {
+      const amrex::Real beta_lo = m_p[idir];
+      const amrex::Real beta_hi = m_p2[idir];
+      const amrex::Real s_c = m_p3[idir];
+      if (std::abs(beta_lo) < BETA_EPS && std::abs(beta_hi) < BETA_EPS) {
+        return x_phys;
+      }
+      const amrex::Real target = clamp01((x_phys - plo) / L);
+      // Newton on f(s) = offset_norm(s) - target, f' = fac(s) > 0, with a
+      // bisection safeguard on the bracket [lo, hi] that always contains
+      // the root because offset_norm is strictly increasing.
+      amrex::Real lo = amrex::Real(0.0);
+      amrex::Real hi = amrex::Real(1.0);
+      amrex::Real s = target;
+      for (int it = 0; it < 50; ++it) {
+        const amrex::Real f =
+          interior_offset_norm(beta_lo, beta_hi, s_c, s) - target;
+        if (std::abs(f) < amrex::Real(1.0e-15)) {
+          break;
+        }
+        if (f > amrex::Real(0.0)) {
+          hi = s;
+        } else {
+          lo = s;
+        }
+        const amrex::Real fp = interior_fac(beta_lo, beta_hi, s_c, s);
+        amrex::Real s_new = s - f / fp;
+        if (!(s_new > lo && s_new < hi)) {
+          s_new = amrex::Real(0.5) * (lo + hi);
+        }
+        const amrex::Real ds = std::abs(s_new - s);
+        s = s_new;
+        if (ds < amrex::Real(1.0e-13)) {
+          break;
+        }
+      }
+      return plo + L * s;
+    }
+    }
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+      false, "MeshMapEvaluator::xi_from_x_phys: unhandled Kind -- a mesh map "
+             "was added without a case in this switch");
+    return std::numeric_limits<amrex::Real>::quiet_NaN();
+  }
+
+  /**
    * \brief Lower-level helper: apply the mapping to an arbitrary
    *        \f$\xi\f$-space coordinate along axis \p idir.
    */
@@ -368,6 +490,14 @@ struct MeshMapEvaluator
       false, "MeshMapEvaluator::x_phys_from_xi: unhandled Kind -- a mesh map "
              "was added without a case in this switch");
     return std::numeric_limits<amrex::Real>::quiet_NaN();
+  }
+
+  /// Clamp a normalized coordinate into [0,1].  Public on purpose: device
+  /// code may need it and GPU builds have tripped over private statics.
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
+  clamp01(amrex::Real v) noexcept
+  {
+    return amrex::min(amrex::Real(1.0), amrex::max(amrex::Real(0.0), v));
   }
 };
 

--- a/Source/Mesh/PeleLMeX_MeshMapEvaluator.H
+++ b/Source/Mesh/PeleLMeX_MeshMapEvaluator.H
@@ -134,6 +134,26 @@ struct MeshMapEvaluator
     return (wall_end == 1) ? (amrex::Real(1.0) - off) : off;
   }
 
+  /**
+   * \brief Inverse of \c exp_offset_norm: the Xi-space fraction \f$s\f$ at
+   *        which the physical fraction \p off is reached.
+   *
+   * Closed form (\c log).  \p off must lie in [0,1]; callers clamp.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
+  exp_offset_inv(amrex::Real off, amrex::Real beta, int wall_end) noexcept
+  {
+    if (std::abs(beta) < BETA_EPS) {
+      return off;
+    }
+    if (wall_end == 1) {
+      off = amrex::Real(1.0) - off;
+    }
+    const amrex::Real den = std::exp(beta) - amrex::Real(1.0);
+    const amrex::Real eta = std::log(off * den + amrex::Real(1.0)) / beta;
+    return (wall_end == 1) ? (amrex::Real(1.0) - eta) : eta;
+  }
+
   // ---- TanhStretchMap primitives (two-sided, clusters at both ends) ----
 
   /**
@@ -166,6 +186,25 @@ struct MeshMapEvaluator
            (amrex::Real(1.0) +
             std::tanh(beta * (amrex::Real(2.0) * s - amrex::Real(1.0))) /
               std::tanh(beta));
+  }
+
+  /**
+   * \brief Inverse of \c tanh_offset_norm: the Xi-space fraction \f$s\f$ at
+   *        which the physical fraction \p off is reached.
+   *
+   * Closed form (\c atanh).  \p off in [0,1] puts the argument in
+   * [-tanh(beta), tanh(beta)], strictly inside atanh's domain for any finite
+   * beta; callers clamp.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
+  tanh_offset_inv(amrex::Real off, amrex::Real beta) noexcept
+  {
+    if (std::abs(beta) < BETA_EPS) {
+      return off;
+    }
+    const amrex::Real arg =
+      (amrex::Real(2.0) * off - amrex::Real(1.0)) * std::tanh(beta);
+    return amrex::Real(0.5) * (amrex::Real(1.0) + std::atanh(arg) / beta);
   }
 
   // ---- InteriorStretchMap primitives -----------------------------------
@@ -273,6 +312,55 @@ struct MeshMapEvaluator
   }
 
   /**
+   * \brief Inverse of \c interior_offset_norm: the Xi-space fraction
+   *        \f$s\f$ at which the physical fraction \p target is reached.
+   *
+   * No closed form (the offset involves
+   * \f$\eta + \sinh(2\beta\eta)/(2\beta)\f$), so this is a Newton iteration
+   * on f(s) = offset_norm(s) - target, whose derivative f' = fac(s) > 0, with
+   * a bisection safeguard on the bracket [lo, hi] that always contains the
+   * root because offset_norm is strictly increasing.  \p target must lie in
+   * [0,1]; callers clamp.
+   */
+  AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static amrex::Real
+  interior_offset_inv(
+    amrex::Real beta_lo,
+    amrex::Real beta_hi,
+    amrex::Real s_c,
+    amrex::Real target) noexcept
+  {
+    if (std::abs(beta_lo) < BETA_EPS && std::abs(beta_hi) < BETA_EPS) {
+      return target;
+    }
+    auto lo = amrex::Real(0.0);
+    auto hi = amrex::Real(1.0);
+    amrex::Real s = target;
+    for (int it = 0; it < 50; ++it) {
+      const amrex::Real f =
+        interior_offset_norm(beta_lo, beta_hi, s_c, s) - target;
+      if (std::abs(f) < amrex::Real(1.0e-15)) {
+        break;
+      }
+      if (f > amrex::Real(0.0)) {
+        hi = s;
+      } else {
+        lo = s;
+      }
+      const amrex::Real fp = interior_fac(beta_lo, beta_hi, s_c, s);
+      amrex::Real s_new = s - f / fp;
+      if (s_new <= lo || s_new >= hi) {
+        s_new = amrex::Real(0.5) * (lo + hi);
+      }
+      const amrex::Real ds = std::abs(s_new - s);
+      s = s_new;
+      if (ds < amrex::Real(1.0e-13)) {
+        break;
+      }
+    }
+    return s;
+  }
+
+  /**
    * \brief Physical coordinate of the cell centre with integer index
    *        \p idx along axis \p idir.
    */
@@ -329,10 +417,10 @@ struct MeshMapEvaluator
    *        whose image under the mapping is \p x_phys, along axis \p idir.
    *
    * Constant, ExpStretch and TanhStretch invert in closed form (\c log and
-   * \c atanh).  InteriorStretch does not -- its offset involves
-   * \f$\eta + \sinh(2\beta\eta)/(2\beta)\f$ -- so it is inverted by a
-   * safeguarded Newton iteration on the monotone forward map, whose
-   * derivative is exactly \c interior_fac.  Use it to turn a physical
+   * \c atanh, see \c exp_offset_inv / \c tanh_offset_inv).  InteriorStretch
+   * does not, so \c interior_offset_inv runs a safeguarded Newton iteration
+   * on the monotone forward map, whose derivative is exactly
+   * \c interior_fac.  Use it to turn a physical
    * position supplied in the inputs (a sampling-plane location, a probe
    * position) into the coordinate that indexes the AMReX grid.
    *
@@ -356,73 +444,27 @@ struct MeshMapEvaluator
 
     case Kind::ExpStretch: {
       const amrex::Real beta = m_p[idir];
-      if (std::abs(beta) < BETA_EPS) {
-        return x_phys;
-      }
-      amrex::Real off = clamp01((x_phys - plo) / L);
-      if (m_q[idir] == 1) {
-        off = amrex::Real(1.0) - off;
-      }
-      const amrex::Real den = std::exp(beta) - amrex::Real(1.0);
-      amrex::Real eta = std::log(off * den + amrex::Real(1.0)) / beta;
-      if (m_q[idir] == 1) {
-        eta = amrex::Real(1.0) - eta;
-      }
-      return plo + L * eta;
+      return (std::abs(beta) < BETA_EPS)
+               ? x_phys
+               : plo + L * exp_offset_inv(
+                            clamp01((x_phys - plo) / L), beta, m_q[idir]);
     }
 
     case Kind::TanhStretch: {
       const amrex::Real beta = m_p[idir];
-      if (std::abs(beta) < BETA_EPS) {
-        return x_phys;
-      }
-      const amrex::Real off = clamp01((x_phys - plo) / L);
-      // off in [0,1] puts the argument in [-tanh(beta), tanh(beta)], which
-      // is strictly inside atanh's domain for any finite beta.
-      const amrex::Real arg =
-        (amrex::Real(2.0) * off - amrex::Real(1.0)) * std::tanh(beta);
-      const amrex::Real eta =
-        amrex::Real(0.5) * (amrex::Real(1.0) + std::atanh(arg) / beta);
-      return plo + L * eta;
+      return (std::abs(beta) < BETA_EPS)
+               ? x_phys
+               : plo + L * tanh_offset_inv(clamp01((x_phys - plo) / L), beta);
     }
 
     case Kind::InteriorStretch: {
       const amrex::Real beta_lo = m_p[idir];
       const amrex::Real beta_hi = m_p2[idir];
-      const amrex::Real s_c = m_p3[idir];
-      if (std::abs(beta_lo) < BETA_EPS && std::abs(beta_hi) < BETA_EPS) {
-        return x_phys;
-      }
-      const amrex::Real target = clamp01((x_phys - plo) / L);
-      // Newton on f(s) = offset_norm(s) - target, f' = fac(s) > 0, with a
-      // bisection safeguard on the bracket [lo, hi] that always contains
-      // the root because offset_norm is strictly increasing.
-      auto lo = amrex::Real(0.0);
-      auto hi = amrex::Real(1.0);
-      amrex::Real s = target;
-      for (int it = 0; it < 50; ++it) {
-        const amrex::Real f =
-          interior_offset_norm(beta_lo, beta_hi, s_c, s) - target;
-        if (std::abs(f) < amrex::Real(1.0e-15)) {
-          break;
-        }
-        if (f > amrex::Real(0.0)) {
-          hi = s;
-        } else {
-          lo = s;
-        }
-        const amrex::Real fp = interior_fac(beta_lo, beta_hi, s_c, s);
-        amrex::Real s_new = s - f / fp;
-        if (s_new <= lo || s_new >= hi) {
-          s_new = amrex::Real(0.5) * (lo + hi);
-        }
-        const amrex::Real ds = std::abs(s_new - s);
-        s = s_new;
-        if (ds < amrex::Real(1.0e-13)) {
-          break;
-        }
-      }
-      return plo + L * s;
+      return (std::abs(beta_lo) < BETA_EPS && std::abs(beta_hi) < BETA_EPS)
+               ? x_phys
+               : plo + L * interior_offset_inv(
+                            beta_lo, beta_hi, m_p3[idir],
+                            clamp01((x_phys - plo) / L));
     }
     }
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(

--- a/Source/Mesh/PeleLMeX_MeshMapEvaluator.H
+++ b/Source/Mesh/PeleLMeX_MeshMapEvaluator.H
@@ -397,8 +397,8 @@ struct MeshMapEvaluator
       // Newton on f(s) = offset_norm(s) - target, f' = fac(s) > 0, with a
       // bisection safeguard on the bracket [lo, hi] that always contains
       // the root because offset_norm is strictly increasing.
-      amrex::Real lo = amrex::Real(0.0);
-      amrex::Real hi = amrex::Real(1.0);
+      auto lo = amrex::Real(0.0);
+      auto hi = amrex::Real(1.0);
       amrex::Real s = target;
       for (int it = 0; it < 50; ++it) {
         const amrex::Real f =
@@ -413,7 +413,7 @@ struct MeshMapEvaluator
         }
         const amrex::Real fp = interior_fac(beta_lo, beta_hi, s_c, s);
         amrex::Real s_new = s - f / fp;
-        if (!(s_new > lo && s_new < hi)) {
+        if (s_new <= lo || s_new >= hi) {
           s_new = amrex::Real(0.5) * (lo + hi);
         }
         const amrex::Real ds = std::abs(s_new - s);

--- a/Source/Mesh/PeleLMeX_MeshMapEvaluator.H
+++ b/Source/Mesh/PeleLMeX_MeshMapEvaluator.H
@@ -447,7 +447,7 @@ struct MeshMapEvaluator
       return (std::abs(beta) < BETA_EPS)
                ? x_phys
                : plo + L * exp_offset_inv(
-                            clamp01((x_phys - plo) / L), beta, m_q[idir]);
+                             clamp01((x_phys - plo) / L), beta, m_q[idir]);
     }
 
     case Kind::TanhStretch: {
@@ -463,8 +463,8 @@ struct MeshMapEvaluator
       return (std::abs(beta_lo) < BETA_EPS && std::abs(beta_hi) < BETA_EPS)
                ? x_phys
                : plo + L * interior_offset_inv(
-                            beta_lo, beta_hi, m_p3[idir],
-                            clamp01((x_phys - plo) / L));
+                             beta_lo, beta_hi, m_p3[idir],
+                             clamp01((x_phys - plo) / L));
     }
     }
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(

--- a/Source/PeleLMeX.H
+++ b/Source/PeleLMeX.H
@@ -1252,6 +1252,24 @@ public:
     const int lev,
     const amrex::Real a_time);
 
+  // Inject synthetic turbulence into one inflow-adjacent ghost box. Wraps
+  // the PelePhysics call so that the mesh-mapping case, which must supply
+  // the injection face's physical cell-centre coordinates rather than let
+  // TurbInflow derive them from the (Xi-space) Geometry, is handled in one
+  // place.
+  void addTurbInflowToBox(
+    const amrex::Box& a_bx,
+    amrex::FArrayBox& a_data,
+    const int lev,
+    const int dir,
+    const amrex::Orientation::Side& a_side,
+    const amrex::Real a_time);
+
+  // Report the ratio of the level-0 grid's physical spacing on each inflow
+  // face to the turbulence file's transverse spacing. Informational only;
+  // called from checkSetupParams().
+  void reportTurbInflowResolution();
+
   void fillFromRecyclingPlane(amrex::MultiFab& a_vel, int vel_comp, int lev);
 
   // Full-mode mass-flux control: rescale the injection buffer's normal

--- a/Source/PeleLMeX_BC.cpp
+++ b/Source/PeleLMeX_BC.cpp
@@ -1230,6 +1230,46 @@ PeleLM::setInflowBoundaryVel(
 }
 
 void
+PeleLM::addTurbInflowToBox(
+  const amrex::Box& a_bx,
+  amrex::FArrayBox& a_data,
+  const int lev,
+  const int dir,
+  const amrex::Orientation::Side& a_side,
+  const amrex::Real a_time)
+{
+#ifdef PELEPHYSICS_TURBINFLOW_HAS_COORD_ADDTURB
+  if (m_mesh_mapping) {
+    // The turbulence file is indexed by PHYSICAL position, whereas
+    // geom[lev] describes the uniform Xi-space grid.  Hand the injection
+    // face's physical cell-centre coordinates to TurbInflow explicitly.
+    //
+    // a_bx comes from adjCell{Lo,Hi}(Domain, dir, .) intersected with a
+    // grown tilebox, so its transverse extents never leave the domain and
+    // the mapping is only ever evaluated inside [ProbLo, ProbHi].
+    int tdir1 = 0;
+    int tdir2 = 0;
+    pele::physics::turbinflow::TurbInflow::transverseDirs(dir, tdir1, tdir2);
+    const auto gd = geom[lev].data();
+
+    amrex::Vector<amrex::Real> x_phys(a_bx.length(tdir1));
+    amrex::Vector<amrex::Real> y_phys(a_bx.length(tdir2));
+    for (int i = 0; i < static_cast<int>(x_phys.size()); ++i) {
+      x_phys[i] = m_map_eval.x_phys_cc(tdir1, a_bx.smallEnd(tdir1) + i, gd);
+    }
+    for (int j = 0; j < static_cast<int>(y_phys.size()); ++j) {
+      y_phys[j] = m_map_eval.x_phys_cc(tdir2, a_bx.smallEnd(tdir2) + j, gd);
+    }
+
+    turb_inflow.add_turb(
+      a_bx, a_data, 0, geom[lev].Domain(), x_phys, y_phys, a_time, dir, a_side);
+    return;
+  }
+#endif
+  turb_inflow.add_turb(a_bx, a_data, 0, geom[lev], a_time, dir, a_side);
+}
+
+void
 PeleLM::fillTurbInflow(
   amrex::MultiFab& a_vel,
   const int vel_comp,
@@ -1288,9 +1328,8 @@ PeleLM::fillTurbInflow(
           data.setVal<amrex::RunOn::Device>(
             0.0, bndryBoxLO_ghost, vel_comp, AMREX_SPACEDIM);
 
-          turb_inflow.add_turb(
-            bndryBoxLO, data, 0, geom[lev], a_time, dir,
-            amrex::Orientation::low);
+          addTurbInflowToBox(
+            bndryBoxLO, data, lev, dir, amrex::Orientation::low, a_time);
         }
 
         auto bndryBoxHI =
@@ -1311,9 +1350,8 @@ PeleLM::fillTurbInflow(
           data.setVal<amrex::RunOn::Device>(
             0.0, bndryBoxHI_ghost, vel_comp, AMREX_SPACEDIM);
 
-          turb_inflow.add_turb(
-            bndryBoxHI, data, 0, geom[lev], a_time, dir,
-            amrex::Orientation::high);
+          addTurbInflowToBox(
+            bndryBoxHI, data, lev, dir, amrex::Orientation::high, a_time);
         }
       }
     }
@@ -1328,10 +1366,14 @@ int
 PeleLM::computeRecyclingSrcIndex(int lev) const
 {
   const int dir = m_inlet_plane_dir;
+  // peleLM.inlet_plane_position is a PHYSICAL coordinate.  Under mesh
+  // mapping the AMReX grid is the uniform Xi grid, so invert the mapping
+  // before converting to an index; with no mapping active the inverse is
+  // the identity and this reduces to the original expression.
+  const amrex::Real xi_position =
+    m_map_eval.xi_from_x_phys(dir, m_inlet_plane_position, geom[lev].data());
   auto srcIndex = static_cast<int>(std::lround(
-    (m_inlet_plane_position - geom[lev].ProbLo()[dir]) /
-      geom[lev].CellSize()[dir] -
-    0.5));
+    (xi_position - geom[lev].ProbLo()[dir]) / geom[lev].CellSize()[dir] - 0.5));
   const auto& dom = geom[lev].Domain();
   AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
     srcIndex >= dom.smallEnd(dir) && srcIndex <= dom.bigEnd(dir),

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -1068,13 +1068,26 @@ PeleLM::checkSetupParams()
       "physical coordinates (PELEPHYSICS_TURBINFLOW_HAS_COORD_ADDTURB).\n"
       "Update Submodules/PelePhysics, or drop geometry.mesh_mapping.");
 #endif
-    // The file format carries no coordinate information, so the data itself
-    // is uniformly spaced regardless of the grid it is injected onto.
-    // Turbulence *generated on* a stretched mesh is not yet supported.
+    // A turbulence file is uniform in *some* coordinate: physical position
+    // for synthetic or uniform-precursor data, but the precursor's Xi
+    // coordinate for planes extracted from a mesh-mapped run (DiagFramePlane
+    // and the plotfile writer both emit the Xi geometry).  The sampling path
+    // used here assumes the former.  A PelePhysics that understands the HDR
+    // MESHMAP_V1 trailer refuses the latter at TurbInflow::init(); an older
+    // one cannot tell them apart, so say so.
+#ifdef PELEPHYSICS_TURBINFLOW_HAS_MESHMAP_HDR
     amrex::Print()
-      << " NOTE: turbinflow data is always uniformly spaced; only the "
-         "target grid may be\n       stretched. Turbulence generated ON a "
-         "stretched mesh is not yet supported.\n";
+      << " NOTE: turbinflow data without a MESHMAP_V1 trailer is taken to be "
+         "uniform in physical\n       position; only the target grid is "
+         "stretched.  Files extracted from a mesh-mapped\n       precursor "
+         "are refused until the sampling path can invert their map.\n";
+#else
+    amrex::Print()
+      << " WARNING: turbinflow data is assumed uniform in physical position. "
+         "This PelePhysics cannot\n          detect a file extracted from a "
+         "mesh-mapped precursor (uniform in that run's Xi\n          "
+         "coordinate); injecting one here would be silently wrong.\n";
+#endif
   }
 
   if (m_mesh_mapping && (m_use_inlet_from_plane != 0) && (verbose != 0)) {

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -1129,14 +1129,12 @@ PeleLM::reportTurbInflowResolution()
       const bool is_low = (iside == 0);
       const auto side =
         is_low ? amrex::Orientation::low : amrex::Orientation::high;
-      const int bctype =
-        is_low ? velBCRec[0].lo()[dir] : velBCRec[0].hi()[dir];
+      const int bctype = is_low ? velBCRec[0].lo()[dir] : velBCRec[0].hi()[dir];
       if (bctype != amrex::BCType::ext_dir) {
         continue;
       }
       amrex::Real file_dx[2] = {0.0, 0.0};
-      if (!turb_inflow.file_transverse_dx(
-            dir, side, file_dx[0], file_dx[1])) {
+      if (!turb_inflow.file_transverse_dx(dir, side, file_dx[0], file_dx[1])) {
         continue;
       }
 

--- a/Source/PeleLMeX_Setup.cpp
+++ b/Source/PeleLMeX_Setup.cpp
@@ -1,3 +1,4 @@
+#include <limits>
 #include <string>
 #include <AMReX_ParmParse.H>
 #include <AMReX_buildInfo.H>
@@ -315,6 +316,11 @@ PeleLM::readParameters()
 
       m_mesh_map = MeshMap::create(mesh_mapping_name);
       m_mesh_mapping = true;
+      // Populate the coordinate evaluator now, rather than waiting for the
+      // Init/Regrid paths: parameter validation further down this function
+      // needs to convert between physical and Xi positions.  Init and
+      // Regrid refresh it from the same source.
+      m_map_eval = m_mesh_map->make_evaluator();
       amrex::Print() << " Mesh mapping enabled: " << mesh_mapping_name << "\n";
     }
   }
@@ -359,12 +365,21 @@ PeleLM::readParameters()
       m_inlet_plane_dir >= 0 && m_inlet_plane_dir < AMREX_SPACEDIM,
       "peleLM.inlet_plane_dir must be set to a valid direction "
       "when peleLM.use_inlet_from_plane is enabled");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
-      m_inlet_plane_position >= geom[0].ProbLo()[m_inlet_plane_dir] &&
-        m_inlet_plane_position <= geom[0].ProbHi()[m_inlet_plane_dir],
-      "peleLM.inlet_plane_position must lie within the problem domain "
-      "bounds in peleLM.inlet_plane_dir when "
-      "peleLM.use_inlet_from_plane is enabled");
+    // inlet_plane_position is a physical coordinate.  Under mesh mapping the
+    // physical domain bounds are the images of the Xi bounds, which for
+    // ConstantMap differ from them; compare against those.
+    {
+      const auto gd = geom[0].data();
+      const amrex::Real phys_lo = m_map_eval.x_phys_from_xi(
+        m_inlet_plane_dir, geom[0].ProbLo()[m_inlet_plane_dir], gd);
+      const amrex::Real phys_hi = m_map_eval.x_phys_from_xi(
+        m_inlet_plane_dir, geom[0].ProbHi()[m_inlet_plane_dir], gd);
+      AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        m_inlet_plane_position >= phys_lo && m_inlet_plane_position <= phys_hi,
+        "peleLM.inlet_plane_position must lie within the physical problem "
+        "domain bounds in peleLM.inlet_plane_dir when "
+        "peleLM.use_inlet_from_plane is enabled");
+    }
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
       m_inlet_plane_warmup_steps >= 0,
       "peleLM.inlet_plane_warmup_steps must be non-negative when "
@@ -1036,6 +1051,108 @@ PeleLM::checkSetupParams()
     }
 #endif
   }
+
+  // ---------------------------------------------------------------------
+  // Mesh mapping x inflow data
+  // ---------------------------------------------------------------------
+  // A turbulence file is indexed by PHYSICAL position, while the AMReX grid
+  // a mesh-mapped run carries is the uniform Xi grid.  Sampling the file
+  // therefore needs the PelePhysics add_turb() overload that accepts
+  // physical coordinates; without it the inflow is silently sampled at Xi
+  // coordinates and the injected turbulence is wrong.
+  if (m_mesh_mapping && turb_inflow.is_initialized()) {
+#ifndef PELEPHYSICS_TURBINFLOW_HAS_COORD_ADDTURB
+    amrex::Abort(
+      "geometry.mesh_mapping combined with turbinflow requires a "
+      "PelePhysics that provides TurbInflow::add_turb() with explicit "
+      "physical coordinates (PELEPHYSICS_TURBINFLOW_HAS_COORD_ADDTURB).\n"
+      "Update Submodules/PelePhysics, or drop geometry.mesh_mapping.");
+#endif
+    // The file format carries no coordinate information, so the data itself
+    // is uniformly spaced regardless of the grid it is injected onto.
+    // Turbulence *generated on* a stretched mesh is not yet supported.
+    amrex::Print()
+      << " NOTE: turbinflow data is always uniformly spaced; only the "
+         "target grid may be\n       stretched. Turbulence generated ON a "
+         "stretched mesh is not yet supported.\n";
+  }
+
+  if (m_mesh_mapping && (m_use_inlet_from_plane != 0) && (verbose != 0)) {
+    const int dir = m_inlet_plane_dir;
+    amrex::Print() << " Recycling source plane: physical position "
+                   << m_inlet_plane_position << " -> Xi position "
+                   << m_map_eval.xi_from_x_phys(
+                        dir, m_inlet_plane_position, geom[0].data())
+                   << " (level-0 index " << computeRecyclingSrcIndex(0)
+                   << ")\n";
+  }
+
+  if (turb_inflow.is_initialized() && (verbose != 0)) {
+    reportTurbInflowResolution();
+  }
+}
+
+void
+PeleLM::reportTurbInflowResolution()
+{
+#ifndef PELEPHYSICS_TURBINFLOW_HAS_COORD_ADDTURB
+  // The accessors this needs (file_transverse_dx, transverseDirs) arrived
+  // with the coordinate-based add_turb overload; without them there is
+  // nothing to report.
+  return;
+#else
+  // Compare the turbulence file's transverse spacing against the level-0
+  // grid's physical spacing on each inflow face.  The ratio is the physical
+  // constraint on injecting a uniformly-spaced file: substantially above one
+  // and the file cannot fill the scales the grid resolves; substantially
+  // below one and the injected field is aliased onto the grid.  Neither is
+  // an error, so this only reports.
+  const auto gd = geom[0].data();
+  const amrex::Box& dom = geom[0].Domain();
+  auto velBCRec = fetchBCRecArray(VELX, AMREX_SPACEDIM);
+
+  for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+    for (int iside = 0; iside < 2; ++iside) {
+      const bool is_low = (iside == 0);
+      const auto side =
+        is_low ? amrex::Orientation::low : amrex::Orientation::high;
+      const int bctype =
+        is_low ? velBCRec[0].lo()[dir] : velBCRec[0].hi()[dir];
+      if (bctype != amrex::BCType::ext_dir) {
+        continue;
+      }
+      amrex::Real file_dx[2] = {0.0, 0.0};
+      if (!turb_inflow.file_transverse_dx(
+            dir, side, file_dx[0], file_dx[1])) {
+        continue;
+      }
+
+      int tdir1 = 0;
+      int tdir2 = 0;
+      pele::physics::turbinflow::TurbInflow::transverseDirs(dir, tdir1, tdir2);
+      const int tdir[2] = {tdir1, tdir2};
+
+      amrex::Print() << " turbInflow resolution check, face (dir " << dir
+                     << ", " << (is_low ? "low" : "high") << "):\n";
+      for (int t = 0; t < 2; ++t) {
+        if (file_dx[t] <= 0.0) {
+          continue;
+        }
+        amrex::Real dmin = std::numeric_limits<amrex::Real>::max();
+        amrex::Real dmax = 0.0;
+        for (int i = dom.smallEnd(tdir[t]); i <= dom.bigEnd(tdir[t]); ++i) {
+          const amrex::Real d = m_map_eval.dx_phys_cc(tdir[t], i, gd);
+          dmin = std::min(dmin, d);
+          dmax = std::max(dmax, d);
+        }
+        amrex::Print() << "   dir " << tdir[t] << ": grid dx in [" << dmin
+                       << ", " << dmax << "], file dx " << file_dx[t]
+                       << " -> dx_grid/dx_file in [" << dmin / file_dx[t]
+                       << ", " << dmax / file_dx[t] << "]\n";
+      }
+    }
+  }
+#endif
 }
 
 void


### PR DESCRIPTION
Linked to PelePhysics#692 This PR stays draft until that PR merges, after which the gitlink will be bumped and Exec/RegTests/TurbInflow/input.3d_TanhStretch becomes runnable.