### PR TITLE
Mesh mapping: scale inflow ghost velocities in the nodal projections

### DIFF
--- a/Source/PeleLMeX_Projection.cpp
+++ b/Source/PeleLMeX_Projection.cpp
@@ -125,8 +125,13 @@ PeleLM::initialProjection()
       auto const& fac_ma = m_mesh_map->fac_cc(lev).const_arrays();
       auto const& detJ_ma = m_mesh_map->detJ_cc(lev).const_arrays();
       auto const& vel_ma = vel[lev]->arrays();
+      // Ghost cells included: setInflowBoundaryVel() has just written the
+      // inflow Dirichlet values there in physical units, and the nodal
+      // projector reads them as the boundary velocity.  Leaving them
+      // unscaled makes the projection enforce u_phys = u_in * fac_n / J
+      // at the inlet instead of u_in.
       amrex::ParallelFor(
-        *vel[lev], amrex::IntVect(0), AMREX_SPACEDIM,
+        *vel[lev], vel[lev]->nGrowVect(), AMREX_SPACEDIM,
         [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k, int n) noexcept {
           vel_ma[box_no](i, j, k, n) *=
             detJ_ma[box_no](i, j, k) / fac_ma[box_no](i, j, k, n);
@@ -181,7 +186,7 @@ PeleLM::initialProjection()
       auto const& detJ_ma = m_mesh_map->detJ_cc(lev).const_arrays();
       auto const& vel_ma = vel[lev]->arrays();
       amrex::ParallelFor(
-        *vel[lev], amrex::IntVect(0), AMREX_SPACEDIM,
+        *vel[lev], vel[lev]->nGrowVect(), AMREX_SPACEDIM,
         [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k, int n) noexcept {
           vel_ma[box_no](i, j, k, n) *=
             fac_ma[box_no](i, j, k, n) / detJ_ma[box_no](i, j, k);
@@ -323,8 +328,13 @@ PeleLM::initialPressProjection()
       auto const& fac_ma = m_mesh_map->fac_cc(lev).const_arrays();
       auto const& detJ_ma = m_mesh_map->detJ_cc(lev).const_arrays();
       auto const& vel_ma = vel[lev].arrays();
+      // Ghost cells included: setInflowBoundaryVel() has just written the
+      // inflow Dirichlet values there in physical units, and the nodal
+      // projector reads them as the boundary velocity.  Leaving them
+      // unscaled makes the projection enforce u_phys = u_in * fac_n / J
+      // at the inlet instead of u_in.
       amrex::ParallelFor(
-        vel[lev], amrex::IntVect(0), AMREX_SPACEDIM,
+        vel[lev], vel[lev].nGrowVect(), AMREX_SPACEDIM,
         [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k, int n) noexcept {
           vel_ma[box_no](i, j, k, n) *=
             detJ_ma[box_no](i, j, k) / fac_ma[box_no](i, j, k, n);
@@ -601,8 +611,13 @@ PeleLM::velocityProjection(
       auto const& fac_ma = m_mesh_map->fac_cc(lev).const_arrays();
       auto const& detJ_ma = m_mesh_map->detJ_cc(lev).const_arrays();
       auto const& vel_ma = vel[lev]->arrays();
+      // Ghost cells included: setInflowBoundaryVel() has just written the
+      // inflow Dirichlet values there in physical units, and the nodal
+      // projector reads them as the boundary velocity.  Leaving them
+      // unscaled makes the projection enforce u_phys = u_in * fac_n / J
+      // at the inlet instead of u_in.
       amrex::ParallelFor(
-        *vel[lev], amrex::IntVect(0), AMREX_SPACEDIM,
+        *vel[lev], vel[lev]->nGrowVect(), AMREX_SPACEDIM,
         [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k, int n) noexcept {
           vel_ma[box_no](i, j, k, n) *=
             detJ_ma[box_no](i, j, k) / fac_ma[box_no](i, j, k, n);
@@ -668,7 +683,7 @@ PeleLM::velocityProjection(
       auto const& detJ_ma = m_mesh_map->detJ_cc(lev).const_arrays();
       auto const& vel_ma = vel[lev]->arrays();
       amrex::ParallelFor(
-        *vel[lev], amrex::IntVect(0), AMREX_SPACEDIM,
+        *vel[lev], vel[lev]->nGrowVect(), AMREX_SPACEDIM,
         [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k, int n) noexcept {
           vel_ma[box_no](i, j, k, n) *=
             fac_ma[box_no](i, j, k, n) / detJ_ma[box_no](i, j, k);


### PR DESCRIPTION
The nodal projections convert the velocity to Xi space (u_i *= J/fac_i) before the solve and back afterwards, but only over the valid region. setInflowBoundaryVel() has just filled the inflow ghost layer in physical units, and the nodal projector reads that layer as the Dirichlet boundary velocity. With a mapping whose J/fac_n differs from one on the inflow face, the projector therefore enforces the wrong inflow.

Reproducer: Exec/RegTests/TurbInflow/input.3d_TanhStretch (x tanh-stretched, beta = 2, z inflow at 5 m/s) with a DiagFramePlane through the first interior cell. Before this change the first-cell z-velocity is 5/fac_x (2.6 m/s at the domain centre, 19 m/s at the walls) with a compensating transverse velocity of +-7 m/s, already after the initial projection. After it, 5.0.

Equivalence check: ConstantMap.scaling_factor = 2 1 1 on a 0.01 Xi domain against an unmapped run on prob_hi = 0.02 with the same n_cell (identical physical mesh, J/fac_z = 2 on the inflow face). Before: the mapped run injects 2.5 m/s. After: the two inflow-plane fields agree with correlation 1.0000 and 0.7% rms difference.

Scope: five scale/unscale loops in PeleLMeX_Projection.cpp now run over the MultiFab's ghost vector. The metric MultiFabs carry m_nGrowState ghosts, filled analytically, so ghost metrics are always defined; ghost cells not written by setInflowBoundaryVel are scaled and restored at round-off. The MAC projection is unaffected (the inflow face is a valid face of umac). Affects any inflow boundary under geometry.mesh_mapping, including ConstantMap with unequal factors. Independent of the turbinflow work in #692: no PelePhysics change, no submodule bump.